### PR TITLE
Stability Fixes for Unified Interface

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/AppElementReference.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/AppElementReference.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             public static string AreaMenu = "Nav_AreaMenu";
             public static string SubAreaContainer = "Nav_SubAreaContainer";
             public static string AppMenuButton = "Nav_AppMenuButton";
+            public static string SiteMapLauncherButton = "Nav_SiteMapLauncherButton";
             public static string AppMenuContainer = "Nav_AppMenuContainer";
             public static string SettingsLauncherBar = "Nav_SettingsLauncherBar";
             public static string SettingsLauncher = "Nav_SettingsLauncher";
@@ -155,6 +156,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             { "Nav_AreaMenu"       , "//*[@id=\"__flyoutRootNode\"]"},
             { "Nav_SubAreaContainer"       , "//*[@id=\"ApplicationShell\"]/div[1]/div[2]/div/div/div[2]/div[3]/ul"},
             { "Nav_AppMenuButton"       , "//*[@id=\"TabArrowDivider\"]/a"},
+            { "Nav_SiteMapLauncherButton", "//button[@data-lp-id=\"sitemap-launcher\"]" },
             { "Nav_AppMenuContainer"       , "//*[@id=\"taskpane-scroll-container\"]"},
             { "Nav_SettingsLauncherBar"       , "//*[@id=\"[NAME]Launcher_buttonaction-bar\"]"},
             { "Nav_SettingsLauncher"       , "//*[@id=\"[NAME]Launcher\"]"},

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -63,7 +63,15 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 driver.FindElement(By.XPath(Elements.Xpath[Reference.Login.UserId])).SendKeys(username.ToUnsecureString());
                 driver.FindElement(By.XPath(Elements.Xpath[Reference.Login.UserId])).SendKeys(Keys.Tab);
                 driver.FindElement(By.XPath(Elements.Xpath[Reference.Login.UserId])).SendKeys(Keys.Enter);
-                Thread.Sleep(2000);
+
+                Thread.Sleep(1000);
+
+                if (driver.IsVisible(By.Id("aadTile")))
+                {
+                    driver.FindElement(By.Id("aadTile")).Click(true);
+                }
+
+                Thread.Sleep(1000);
 
                 //If expecting redirect then wait for redirect to trigger
                 if (redirectAction != null)
@@ -89,7 +97,11 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 
                     driver.WaitUntilVisible(By.XPath(Elements.Xpath[Reference.Login.CrmMainPage])
                         , new TimeSpan(0, 0, 60),
-                        e => { e.WaitForPageToLoad(); },
+                        e => {
+                            e.WaitForPageToLoad();
+                            e.SwitchTo().Frame(0);
+                            e.WaitForPageToLoad();
+                        },
                         f => { throw new Exception("Login page failed."); });
                 }
             }
@@ -119,7 +131,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                     throw new InvalidOperationException($"App Name {appName} not found.");
 
                 driver.WaitUntilVisible(By.XPath(AppElements.Xpath[AppReference.Application.Shell]));
-                driver.WaitUntilVisible(By.XPath(AppElements.Xpath[AppReference.Navigation.AppMenuButton]));
+                driver.WaitUntilVisible(By.XPath(AppElements.Xpath[AppReference.Navigation.SiteMapLauncherButton]));
                 driver.WaitForPageToLoad();
 
                 return true;
@@ -627,8 +639,6 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                         throw new InvalidOperationException($"No sub command with the name '{subname}' exists inside of Commandbar.");
 
                 }
-               
-
                 return true;
             });
         }

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -639,6 +639,9 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                         throw new InvalidOperationException($"No sub command with the name '{subname}' exists inside of Commandbar.");
 
                 }
+
+                driver.WaitForTransaction();
+
                 return true;
             });
         }


### PR DESCRIPTION
Added fixes for Login and ClickCommand methods

Login: Ensure both the main window and content window return document readyState complete before moving to subsequent test methods

ClickCommand: Ensure Unified Interface transaction has completed before moving to subsequent test methods