### PR TITLE
Update reference to anchor tag so click executes as expected

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api/Pages/Entity.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api/Pages/Entity.cs
@@ -295,7 +295,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api
 
             return this.Execute(GetOptions($"Click GridView button of {subgridName}"), driver =>
             {
-                driver.FindElement(By.Id($"{subgridName}_openAssociatedGridViewImageButtonImage"))?.Click();
+                driver.FindElement(By.Id($"{subgridName}_openAssociatedGridViewImageButton"))?.Click();
 
                 return true;
             });


### PR DESCRIPTION
The id that `ClickSubgridGridViewButton()` was referring to was the image and not the anchor tag of the grid view button.  Because of this, executing the command resulted in nothing happening.