### PR TITLE
Committing bug fixes

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/AppElementReference.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/AppElementReference.cs
@@ -216,7 +216,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             { "Entity_RecordSetNavCollapseIcon", "//*[contains(@data-id, 'recordSetNavCollapseIcon')]" },
             { "Entity_RecordSetNavCollapseIconParent", "//*[contains(@data-id, 'recordSetNavCollapseIcon')]" },
             { "Entity_TabList", "//ul[@id=\"tablist\"]" },
-            { "Entity_Tab", "//li[@aria-label=\"{0}\"]" },
+            { "Entity_Tab", "//li[@title=\"{0}\"]" },
             { "Entity_SubTab", "//div[@id=\"__flyoutRootNode\"]//span[text()=\"{0}\"]" },
             { "Entity_FieldControlDateTimeInput","//input[contains(@id,'[FIELD].fieldControl-date-time-input')]" },
                         

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/ElementReference.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/ElementReference.cs
@@ -183,7 +183,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             { "Login_Password", "//input[@type='password']"},
             { "Login_SignIn", "id(\"cred_sign_in_button\")"},
             { "Login_CrmMainPage", "id(\"crmTopBar\")"},
-            { "Login_StaySignedIn", "id(\"idSIButton9\")"},
+            { "Login_StaySignedIn", "//input[@id=\"idSIButton9\"]"},
 
             //Notification           
             { "Notification_AppMessageBar", "id(\"crmAppMessageBar\")"},

--- a/Microsoft.Dynamics365.UIAutomation.Browser/Extensions/SeleniumExtensions.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Browser/Extensions/SeleniumExtensions.cs
@@ -12,6 +12,7 @@ using System.Diagnostics;
 using System.Drawing;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Web.Script.Serialization;
 
 namespace Microsoft.Dynamics365.UIAutomation.Browser
@@ -58,7 +59,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Browser
             WaitUntilClickable(driver,
                                 by,
                                 timeout,
-                                d => { element.Click(); },
+                                d => { element.Click(true); },
                                 e => { throw new InvalidOperationException($"Unable to click element."); });
 
 
@@ -279,9 +280,12 @@ namespace Microsoft.Dynamics365.UIAutomation.Browser
             if (clear)
             {
                 element.Clear();
+                element.SendKeys(value);
             }
-
-            element.SendKeys(value);
+            else
+            {
+                element.SendKeys(value);
+            }
         }
 
         public static bool AlertIsPresent(this IWebDriver driver)


### PR DESCRIPTION
- Unified Interface SelectTab method clicks wrong location
      Modified xpath to look at title instead of aria-label
	
- StaySignedIn dialog not being clicked in IE browser
	Updated xpath reference to look for input tag
	Added Thread.Sleep prior to the StaySignedIn method check
	Added WaitUntilVisible check to ensure element is visible prior to checking

- Unified Interface navigation methods break after login
	Added SwitchTo().DefaultContent() call prior to exiting the check that main page is loaded
	
- Unified Interface OpenApp() method is unable to identify app by name
	New carriage returns were added to underlying DOM structure. Added a Trim() method to the name check to remove unexpected characters.
	
- Unified Interface methods attempt to continue prior to completion of OpenApp() method
	Added a WaitForTransaction() call to verify that the app is loaded before moving to next steps
	
- Unified Interface methods attempt to continue prior to completion of OpenSubArea() method
	Added a WaitForTransactoin() call to verify that the app sub area is loaded before moving to next steps
	
- Unified Interface SelectTab method clicks too quickly
	Added ThinkTime parameter with default think time, or allow user to input larger value as required. 
	
- Unified Interface Select Lookup method comparison is case sensitive
	Added ToLower() method to both sides of the comparison check to eliminate issues due to case sensitive text