### PR TITLE
Working with hidden subareas (displayed on the second page)

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api/Pages/Navigation.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api/Pages/Navigation.cs
@@ -450,8 +450,6 @@ namespace Microsoft.Dynamics365.UIAutomation.Api
 
                 driver.WaitUntilVisible(By.XPath(Elements.Xpath[Reference.Navigation.SubActionGroupContainer]));
 
-                Thread.Sleep(1000);
-
                 var subNavElement = driver.FindElement(By.XPath(Elements.Xpath[Reference.Navigation.SubActionGroupContainer]));
 
                 var subItems = subNavElement.FindElements(By.ClassName(Elements.CssClass[Reference.Navigation.SubActionElementClass]));

--- a/Microsoft.Dynamics365.UIAutomation.Api/Pages/Navigation.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api/Pages/Navigation.cs
@@ -101,7 +101,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api
                 {
                     subAreas[subArea].Click();
                 }
-                catch(Exception ex)
+                catch(ElementNotVisibleException )
                 {
                     //The subarea might be displayed on the second/etc page
                     //Then try using javascript as per
@@ -463,7 +463,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api
                     {
                         var text = subItem.GetAttribute("text");
                         if (!string.IsNullOrEmpty(text))
-                            dictionary.Add(text.ToLowerString(), subItem);
+                           dictionary.Add(text.ToLowerString(), subItem);
                     }
                     
                 }


### PR DESCRIPTION
A couple of changes in the Navigation.cs to make OpenSubArea work with the hidden subareas (those which are displayed on the second page)