### PR TITLE
Updating OpenRecord method XPath reference.

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api/DTOs/ElementReference.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api/DTOs/ElementReference.cs
@@ -108,7 +108,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api
             { "Grid_FindCriteria"       , "id(\"crmGrid_findCriteria\")"},
             { "Grid_GridBodyTable"   , "id(\"gridBodyTable\")" },
             { "Grid_GridBodyTable_Row", "tbody/tr" },
-            { "Grid_GridBodyTable_RowSpan", "descendant::span[not(ancestor::a) and not(descendant::a)]"},
+            { "Grid_GridBodyTable_RowCheckbox", "td[1]"},
             { "Grid_DefaultViewIcon"   , "id(\"defaultViewIcon\")" },
             { "Grid_ViewSelector"   , "id(\"crmGrid_SavedNewQuerySelector\")" },
             { "Grid_Refresh"   , "id(\"grid_refresh\")" },
@@ -564,7 +564,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api
             public static string FindCriteriaImg = "Grid_FindCriteriaImg";
             public static string GridBodyTable = "Grid_GridBodyTable";
             public static string GridBodyTableRow = "Grid_GridBodyTable_Row";
-            public static string GridBodyTableRowSpan = "Grid_GridBodyTable_RowSpan";
+            public static string GridBodyTableRowCheckbox = "Grid_GridBodyTable_RowCheckbox";
             public static string FindCriteria = "Grid_FindCriteria";
             public static string ViewSelector = "Grid_ViewSelector";
             public static string Refresh = "Grid_Refresh";

--- a/Microsoft.Dynamics365.UIAutomation.Api/Pages/Grid.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api/Pages/Grid.cs
@@ -233,23 +233,15 @@ namespace Microsoft.Dynamics365.UIAutomation.Api
                 var rowType = driver.FindElement(By.XPath(Elements.Xpath[Reference.Grid.FirstRow])).GetAttribute("otypename");
 
                 var itemsTable = driver.WaitUntilAvailable(By.XPath(Elements.Xpath[Reference.Grid.GridBodyTable]));
-                var links = itemsTable.FindElements(By.XPath(Elements.Xpath[Reference.Grid.GridBodyTableRow]));
+                var rows = itemsTable.FindElements(By.XPath(Elements.Xpath[Reference.Grid.GridBodyTableRow]));
 
                 var clicked = false;
 
-                if (links.Any() && (index) < links.Count)
+                if (rows.Any() && (index) < rows.Count)
                 {
-                    // look for any span tag within the tr and click on that
-                    var blankSpans = links[index].FindElements(By.XPath(Elements.Xpath[Reference.Grid.GridBodyTableRowSpan]));
-                    if (blankSpans.Any())
-                    {
-                        driver.DoubleClick(blankSpans[0]);
-                    }
-                    else
-                    {
-                        // as a fall back click on the row
-                        driver.DoubleClick(links[index]);
-                    }
+
+                    driver.DoubleClick(rows[index].FindElement(By.XPath(Elements.Xpath[Reference.Grid.GridBodyTableRowCheckbox])));
+
                     clicked = true;
                 }
                 else

--- a/Microsoft.Dynamics365.UIAutomation.Sample/TestSettings.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Sample/TestSettings.cs
@@ -16,8 +16,8 @@ namespace Microsoft.Dynamics365.UIAutomation.Sample
         public static BrowserOptions Options = new BrowserOptions
                                                 {
             BrowserType = (BrowserType)Enum.Parse(typeof(BrowserType), Type),
-                                                    PrivateMode = true,
-            FireEvents = true,
+            PrivateMode = true,
+            FireEvents = false,
             Headless = false,
             UserAgent = false
                                                 };


### PR DESCRIPTION
- Updating OpenRecord method XPath reference.
  - Fix issues with OpenRecord not opening the expected index position in the data table.

- Set Default FireEvents to false in sample project TestSettings
  - Resolves issues with IE browser by default
  

Related Issue #123 