### PR TITLE
SelectLookup fixes for Unified Interface

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/AppElementReference.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/AppElementReference.cs
@@ -60,6 +60,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             public static string TextFieldContainer = "Entity_TextFieldContainer";
             public static string TextFieldLookup = "Entity_TextFieldLookup";
             public static string TextFieldLookupMenu = "Entity_TextFieldLookupMenu";
+            public static string LookupResultsDropdown = "Entity_LookupResultsDropdown";
             public static string TextFieldLookupFieldContainer = "Entity_TextFieldLookupFieldContainer";
             public static string RecordSetNavigator = "Entity_RecordSetNavigator";
             public static string RecordSetNavigatorOpen = "Entity_RecordSetNavigatorOpen";
@@ -219,6 +220,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             { "Entity_Tab", "//li[@title=\"{0}\"]" },
             { "Entity_SubTab", "//div[@id=\"__flyoutRootNode\"]//span[text()=\"{0}\"]" },
             { "Entity_FieldControlDateTimeInput","//input[contains(@id,'[FIELD].fieldControl-date-time-input')]" },
+            { "Entity_LookupResultsDropdown", "//*[contains(@data-id, \'[NAME].fieldControl-LookupResultsDropdown_[NAME]_tab')]" },
                         
             //CommandBar
             { "Cmd_Container"       , "//ul[contains(@data-lp-id,\"commandbar-Form\")]"},

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/AppElementReference.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/AppElementReference.cs
@@ -60,6 +60,8 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             public static string TextFieldContainer = "Entity_TextFieldContainer";
             public static string TextFieldLookup = "Entity_TextFieldLookup";
             public static string TextFieldLookupMenu = "Entity_TextFieldLookupMenu";
+            public static string LookupFieldDeleteExistingValue = "Entity_LookupFieldDeleteExistingValue";
+            public static string LookupFieldHoverExistingValue = "Entity_LookupFieldHoverExistingValue";
             public static string LookupResultsDropdown = "Entity_LookupResultsDropdown";
             public static string TextFieldLookupFieldContainer = "Entity_TextFieldLookupFieldContainer";
             public static string RecordSetNavigator = "Entity_RecordSetNavigator";
@@ -210,6 +212,8 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             { "Entity_TextFieldContainer", "//*[contains(@id, \'[NAME]-FieldSectionItemContainer\')]" },
             { "Entity_TextFieldLookup", "//*[contains(@id, \'systemuserview_id.fieldControl-LookupResultsDropdown')]" },
             { "Entity_TextFieldLookupMenu", "//*[contains(@id, \'[NAME].fieldControl|__flyoutRootNode_SimpleLookupControlFlyout')]" },
+            { "Entity_LookupFieldDeleteExistingValue", "//*[contains(@data-id, \'[NAME].fieldControl-LookupResultsDropdown_[NAME]_selected_tag_delete')]" },
+            { "Entity_LookupFieldHoverExistingValue", "//*[contains(@data-id, \'[NAME].fieldControl-LookupResultsDropdown_[NAME]_SelectedRecordList')]" },
             { "Entity_TextFieldLookupFieldContainer", "//*[contains(@id, '[NAME].fieldControl-LookupResultsDropdown')]" },
             { "Entity_RecordSetNavigatorOpen", "//button[contains(@data-lp-id, 'recordset-navigator')]" },
             { "Entity_RecordSetNavigator", "//button[contains(@data-lp-id, 'recordset-navigator')]" },

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/Elements/Entity.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/Elements/Entity.cs
@@ -24,9 +24,9 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             _client.SetValue(field, value);
         }
 
-        public void SetValue(LookupItem control)
+        public void SetValue(LookupItem control, int index = 0)
         {
-            _client.SetValue(control);
+            _client.SetValue(control, index);
         }
 
         public void SetValue(OptionSet optionSet)

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -1205,7 +1205,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         /// </summary>
         /// <param name="control">The lookup field name, value or index of the lookup.</param>
         /// <example>xrmApp.Entity.SetValue(new Lookup { Name = "prrimarycontactid", Value = "Rene Valdes (sample)" });</example>
-        internal BrowserCommandResult<bool> SetValue(LookupItem control)
+        internal BrowserCommandResult<bool> SetValue(LookupItem control, int index = 0)
         {
             return this.Execute(GetOptions($"Set Lookup Value: {control.Name}"), driver =>
             {
@@ -1229,10 +1229,10 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 
                     if (control.Value != null)
                     {
-                        if (!dialogItems.Exists(x => x.Title == control.Value))
+                        if (!dialogItems.Exists(x => x.Title.ToLower() == control.Value.ToLower()))
                             throw new InvalidOperationException($"List does not have {control.Value}.");
 
-                        var dialogItem = dialogItems.Where(x => x.Title.ToLower() == control.Value.ToLower()).First();
+                        var dialogItem = dialogItems.Where(x => x.Title.ToLower() == control.Value.ToLower().[index]);
                         driver.ClickWhenAvailable(By.Id(dialogItem.Id));
                     }
                     else

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -1235,12 +1235,23 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         /// </summary>
         /// <param name="control">The lookup field name, value or index of the lookup.</param>
         /// <example>xrmApp.Entity.SetValue(new Lookup { Name = "prrimarycontactid", Value = "Rene Valdes (sample)" });</example>
-        /// The default index position is 0, which will be the first results record in the lookup results window. Suppy a value > 0 to select a different record if multiple are present.
+        /// The default index position is 0, which will be the first result record in the lookup results window. Suppy a value > 0 to select a different record if multiple are present.
         internal BrowserCommandResult<bool> SetValue(LookupItem control, int index = 0)
         {
             return this.Execute(GetOptions($"Set Lookup Value: {control.Name}"), driver =>
             {
                 var fieldContainer = driver.WaitUntilAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.TextFieldLookupFieldContainer].Replace("[NAME]", control.Name)));
+
+                if (fieldContainer.FindElements(By.TagName("input")).Count == 0)
+                {
+                    var existingLookupValue = fieldContainer.FindElement(By.XPath(AppElements.Xpath[AppReference.Entity.LookupFieldHoverExistingValue].Replace("[NAME]", control.Name)));
+                    existingLookupValue.Hover(driver);
+                    
+                    var deleteExistingLookupValue = fieldContainer.FindElement(By.XPath(AppElements.Xpath[AppReference.Entity.LookupFieldDeleteExistingValue].Replace("[NAME]", control.Name)));
+                    deleteExistingLookupValue.Click();
+                }
+
+                fieldContainer = driver.WaitUntilAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.TextFieldLookupFieldContainer].Replace("[NAME]", control.Name)));
 
                 if (fieldContainer.FindElements(By.TagName("input")).Count > 0)
                 {

--- a/Microsoft.Dynamics365.UIAutomation.Browser/Extensions/SeleniumExtensions.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Browser/Extensions/SeleniumExtensions.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Browser
             return driver;
         }
 
-        public static void Click(this IWebElement element, bool ignoreStaleElementException = false)
+        public static void Click(this IWebElement element, bool ignoreStaleElementException = true)
         {
             try
             {
@@ -44,6 +44,20 @@ namespace Microsoft.Dynamics365.UIAutomation.Browser
             {
                 if (!ignoreStaleElementException)
                     throw ex;
+            }
+        }
+
+        public static void Hover(this IWebElement Element, IWebDriver driver, bool ignoreStaleElementException = true)
+        {
+            try
+            {
+                Actions action = new Actions(driver);
+                action.MoveToElement(Element).Build().Perform();
+            }
+            catch (StaleElementReferenceException ex)
+            {
+                if (!ignoreStaleElementException)
+                    throw;
             }
         }
 


### PR DESCRIPTION
Regarding Issue #149 
1. Checking for results in the flyout dialog is no longer case sensitive
2. Lookup flyout dialog should remain open, avoiding unexpected 'value does not exist' errors
3. Added index parameter to allow picking of any value available in the drop down, default to first item in the list if no index parameter is provided
4. Allow input search text of "" for testing the 'Recently Viewed' drop down, if recently viewed records are available for the user
5. If the lookup field already contains a value, clear the field (hover, then click the delete button), then apply the new value as desired. 