### PR TITLE
Changes for OpenSubArea navigation in Unified Interface

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/AppElementReference.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/AppElementReference.cs
@@ -170,9 +170,9 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             { "App_Shell"    , "//*[@id=\"ApplicationShell\"]"},
 
             //Navigation
-            { "Nav_AreaButton"       , "//button[contains(@aria-label,'All Areas')]"},
-            { "Nav_AreaMenu"       , "//*[@id=\"__flyoutRootNode\"]"},
-            { "Nav_SubAreaContainer"       , "//*[@id=\"ApplicationShell\"]/div[1]/div[2]/div/div/div[2]/div[3]/ul"},
+            { "Nav_AreaButton"       , "//button[contains(@data-lp-id,'sitemap-areaBar-more-btn')]"},
+            { "Nav_AreaMenu"       , "//*[@data-lp-id=\"sitemap-areabar-overflow-flyout\"]"},
+            { "Nav_SubAreaContainer"       , "//*[@data-id=\"navbar-container\"]/div/ul"},
             { "Nav_AppMenuButton"       , "//*[@id=\"TabArrowDivider\"]/a"},
             { "Nav_SiteMapLauncherButton", "//button[@data-lp-id=\"sitemap-launcher\"]" },
             { "Nav_AppMenuContainer"       , "//*[@id=\"taskpane-scroll-container\"]"},

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -260,13 +260,20 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             {
                 var dictionary = new Dictionary<string, IWebElement>();
 
+                driver.ClickWhenAvailable(By.XPath(AppElements.Xpath[AppReference.Navigation.SiteMapLauncherButton]));
+
                 var menuContainer = driver.WaitUntilAvailable(By.XPath(AppElements.Xpath[AppReference.Navigation.SubAreaContainer]));
                 
                 var subItems = menuContainer.FindElements(By.TagName("li"));
 
                 foreach (var subItem in subItems)
                 {
-                    dictionary.Add(subItem.GetAttribute("title").ToLowerString(), subItem);
+                        if(!String.IsNullOrEmpty(subItem.GetAttribute("Id")))
+                    {
+                        if (subItem.GetAttribute("Id").StartsWith("sitemap", StringComparison.OrdinalIgnoreCase))
+                            dictionary.Add(subItem.Text.ToLowerString(), subItem);
+                    }
+                        
                 }
 
                 return dictionary;

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -268,10 +268,12 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 
                 foreach (var subItem in subItems)
                 {
+                        // Check 'Id' attribute, NULL value == Group Header
                         if(!String.IsNullOrEmpty(subItem.GetAttribute("Id")))
-                    {
-                        if (subItem.GetAttribute("Id").StartsWith("sitemap", StringComparison.OrdinalIgnoreCase))
-                            dictionary.Add(subItem.Text.ToLowerString(), subItem);
+                    {              
+                        // Filter out duplicate entity keys - click the first one in the list
+                        if(!dictionary.ContainsKey(subItem.Text.ToLowerString()))
+                                dictionary.Add(subItem.Text.ToLowerString(), subItem);
                     }
                         
                 }


### PR DESCRIPTION
This includes tweaks to change the area (e.g. Sales, Service, Marketing, Project Service, …), and then subsequent changes to retrieve sub-areas (entities) via the SiteMap Launcher.