### PR TITLE
Clear Search box on entity grid capability for Webclient and UCI

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/AppElementReference.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/AppElementReference.cs
@@ -170,9 +170,9 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             { "App_Shell"    , "//*[@id=\"ApplicationShell\"]"},
 
             //Navigation
-            { "Nav_AreaButton"       , "//button[contains(@aria-label,'All Areas')]"},
-            { "Nav_AreaMenu"       , "//*[@id=\"__flyoutRootNode\"]"},
-            { "Nav_SubAreaContainer"       , "//*[@id=\"ApplicationShell\"]/div[1]/div[2]/div/div/div[2]/div[3]/ul"},
+            { "Nav_AreaButton"       , "//button[contains(@data-lp-id,'sitemap-areaBar-more-btn')]"},
+            { "Nav_AreaMenu"       , "//*[@data-lp-id=\"sitemap-areabar-overflow-flyout\"]"},
+            { "Nav_SubAreaContainer"       , "//*[@data-id=\"navbar-container\"]/div/ul"},
             { "Nav_AppMenuButton"       , "//*[@id=\"TabArrowDivider\"]/a"},
             { "Nav_SiteMapLauncherButton", "//button[@data-lp-id=\"sitemap-launcher\"]" },
             { "Nav_AppMenuContainer"       , "//*[@id=\"taskpane-scroll-container\"]"},

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/Elements/Grid.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/Elements/Grid.cs
@@ -21,9 +21,14 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         {
             _client.OpenRecord(index);
         }
-        public void Search(string searchCriteria)
+        public void Search(string searchCriteria, bool clearByDefault = true)
         {
-            _client.Search(searchCriteria);
+            _client.Search(searchCriteria, clearByDefault);
+        }
+
+        public void ClearSearch()
+        {
+            _client.ClearSearch();
         }
 
         public void GetGridItems()

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -842,17 +842,37 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 return true;
             });
         }
-        internal BrowserCommandResult<bool> Search(string searchCriteria, int thinkTime = Constants.DefaultThinkTime)
+        internal BrowserCommandResult<bool> Search(string searchCriteria, bool clearByDefault = true, int thinkTime = Constants.DefaultThinkTime)
         {
             this.Browser.ThinkTime(thinkTime);
 
             return this.Execute(GetOptions($"Search"), driver =>
             {
                 driver.WaitUntilClickable(By.XPath(AppElements.Xpath[AppReference.Grid.QuickFind]));
+
+                if (clearByDefault)
+                {
+                    driver.FindElement(By.XPath(AppElements.Xpath[AppReference.Grid.QuickFind])).Clear();
+                }
+
                 driver.FindElement(By.XPath(AppElements.Xpath[AppReference.Grid.QuickFind])).SendKeys(searchCriteria);
                 driver.FindElement(By.XPath(AppElements.Xpath[AppReference.Grid.QuickFind])).SendKeys(Keys.Enter);
 
                 //driver.WaitForTransaction();
+
+                return true;
+            });
+        }
+
+        internal BrowserCommandResult<bool> ClearSearch(int thinkTime = Constants.DefaultThinkTime)
+        {
+            this.Browser.ThinkTime(thinkTime);
+
+            return this.Execute(GetOptions($"Search"), driver =>
+            {
+                driver.WaitUntilClickable(By.XPath(AppElements.Xpath[AppReference.Grid.QuickFind]));
+
+                driver.FindElement(By.XPath(AppElements.Xpath[AppReference.Grid.QuickFind])).Clear();
 
                 return true;
             });

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -260,13 +260,22 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             {
                 var dictionary = new Dictionary<string, IWebElement>();
 
+                driver.ClickWhenAvailable(By.XPath(AppElements.Xpath[AppReference.Navigation.SiteMapLauncherButton]));
+
                 var menuContainer = driver.WaitUntilAvailable(By.XPath(AppElements.Xpath[AppReference.Navigation.SubAreaContainer]));
                 
                 var subItems = menuContainer.FindElements(By.TagName("li"));
 
                 foreach (var subItem in subItems)
                 {
-                    dictionary.Add(subItem.GetAttribute("title").ToLowerString(), subItem);
+                        // Check 'Id' attribute, NULL value == Group Header
+                        if(!String.IsNullOrEmpty(subItem.GetAttribute("Id")))
+                    {              
+                        // Filter out duplicate entity keys - click the first one in the list
+                        if(!dictionary.ContainsKey(subItem.Text.ToLowerString()))
+                                dictionary.Add(subItem.Text.ToLowerString(), subItem);
+                    }
+                        
                 }
 
                 return dictionary;

--- a/Microsoft.Dynamics365.UIAutomation.Api/Pages/Grid.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api/Pages/Grid.cs
@@ -180,17 +180,43 @@ namespace Microsoft.Dynamics365.UIAutomation.Api
         /// Searches the specified search criteria.
         /// </summary>
         /// <param name="searchCriteria">The search criteria.</param>
+        /// <param name="clearByDefault">By default, clear existing search criteria</param>
         /// <param name="thinkTime">Used to simulate a wait time between human interactions. The Default is 2 seconds.</param>
         /// <example>xrmBrowser.Grid.Search("Test API");</example>
-        public BrowserCommandResult<bool> Search(string searchCriteria, int thinkTime = Constants.DefaultThinkTime)
+        public BrowserCommandResult<bool> Search(string searchCriteria, bool clearByDefault = true, int thinkTime = Constants.DefaultThinkTime)
         {
             Browser.ThinkTime(thinkTime);
 
             return this.Execute(GetOptions("Search"), driver =>
             {
                 driver.WaitUntilClickable(By.XPath(Elements.Xpath[Reference.Grid.FindCriteria]));
+
+                if (clearByDefault)
+                {
+                    driver.FindElement(By.XPath(Elements.Xpath[Reference.Grid.FindCriteria])).Clear();
+                }
+
                 driver.FindElement(By.XPath(Elements.Xpath[Reference.Grid.FindCriteria])).SendKeys(searchCriteria);
                 driver.FindElement(By.XPath(Elements.Xpath[Reference.Grid.FindCriteria])).SendKeys(Keys.Enter);
+
+                return true;
+            });
+        }
+
+        /// <summary>
+        /// Clears the search box on the grid
+        /// </summary>
+        /// <param name="thinkTime">Used to simulate a wait time between human interactions. The Default is 2 seconds.</param>
+        /// <example>xrmBrowser.Grid.ClearSearch();</example>
+        public BrowserCommandResult<bool> ClearSearch(int thinkTime = Constants.DefaultThinkTime)
+        {
+            Browser.ThinkTime(thinkTime);
+
+            return this.Execute(GetOptions("Search"), driver =>
+            {
+                driver.WaitUntilClickable(By.XPath(Elements.Xpath[Reference.Grid.FindCriteria]));
+
+                driver.FindElement(By.XPath(Elements.Xpath[Reference.Grid.FindCriteria])).Clear();
 
                 return true;
             });


### PR DESCRIPTION
**Web Client Changes:** 
Updating Grid.Search method to clear existing values by default
Added new method Grid.ClearSearch(); to clear a searched value if desired.

**Unified Interface Changes:** 
Added clearByDefault capability to existing Grid.Search method. Clears search box automatically. Ability to disable by passing False after search criteria
Addes new Grid.ClearSearch method to clear a search box after performing a search, if desired.