### PR TITLE
add gettabstate method for web client

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api/Pages/Entity.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api/Pages/Entity.cs
@@ -199,6 +199,36 @@ namespace Microsoft.Dynamics365.UIAutomation.Api
         }
 
         /// <summary>
+        /// Returns the state of the tab, either Expanded or Collapsed. 
+        /// </summary>
+        /// <param name="name">The name of the tab.</param>
+        /// <param name="thinkTime">Used to simulate a wait time between human interactions. The Default is 2 seconds.</param>
+        /// <example>xrmBrowser.Entity.GetTabState("Details");</example>
+        public BrowserCommandResult<string> GetTabState(string name, int thinkTime = Constants.DefaultThinkTime)
+        {
+            Browser.ThinkTime(thinkTime);
+
+            return this.Execute(GetOptions($"SelectTab: {name}"), driver =>
+            {
+                if (!driver.HasElement(By.XPath(Elements.Xpath[Reference.Entity.Tab].Replace("[NAME]", name))))
+                {
+                    throw new InvalidOperationException($"Tab with name '{name}' does not exist.");
+                }
+                var tab = driver.WaitUntilAvailable(By.XPath(Elements.Xpath[Reference.Entity.Tab].Replace("[NAME]", name)));
+                var tabState = "";
+
+                if (!tab.GetAttribute("title").Contains("Collapse"))
+                    tabState = "Collapsed";
+                else if (!tab.GetAttribute("title").Contains("Expand"))
+                    tabState = "Expanded";
+                else
+                    throw new InvalidOperationException("Unexpected tab state. Tab state should be either Collapsed or Expanded");
+
+                return tabState;
+            });
+        }
+
+        /// <summary>
         /// Collapses the Tab on a CRM Entity form.
         /// </summary>
         /// <param name="name">The name of the Tab.</param>

--- a/Microsoft.Dynamics365.UIAutomation.Sample/Web/Entity/Account.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Sample/Web/Entity/Account.cs
@@ -81,6 +81,8 @@ namespace Microsoft.Dynamics365.UIAutomation.Sample.Web
 
             if (tabState != "Expanded")
                 XrmTestBrowser.Entity.ExpandTab("Scheduling");
+
+            XrmTestBrowser.ThinkTime(5000);
         }
 
         [TestMethod]

--- a/Microsoft.Dynamics365.UIAutomation.Sample/Web/Entity/Account.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Sample/Web/Entity/Account.cs
@@ -4,6 +4,7 @@
 namespace Microsoft.Dynamics365.UIAutomation.Sample.Web
 {
     using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using System;
 
     [TestClass]
     public class TestAccount : TestBase
@@ -20,7 +21,13 @@ namespace Microsoft.Dynamics365.UIAutomation.Sample.Web
         public void WEBTestCollapseTab()
         {
             if (!HasData) return;
-            XrmTestBrowser.Entity.CollapseTab("Summary");
+
+            var tabState = XrmTestBrowser.Entity.GetTabState("Summary");
+
+            if (tabState.Value != "Collapsed")
+                XrmTestBrowser.Entity.CollapseTab("Summary");
+
+
             XrmTestBrowser.ThinkTime(5000);
         }
 
@@ -69,8 +76,11 @@ namespace Microsoft.Dynamics365.UIAutomation.Sample.Web
         public void WEBTestExpandTab()
         {
             if (!HasData) return;
-            XrmTestBrowser.Entity.CollapseTab("Summary");
-            XrmTestBrowser.Entity.ExpandTab("Summary");
+
+            var tabState = XrmTestBrowser.Entity.GetTabState("Scheduling");
+
+            if (tabState != "Expanded")
+                XrmTestBrowser.Entity.ExpandTab("Scheduling");
         }
 
         [TestMethod]


### PR DESCRIPTION
xrmBrowser.Entity.GetTabState("tabname")

Returns tabState, either 'Expanded' or 'Collapsed'. Suggested use is to return this value and depending on the desired tabState, call ExpandTab("tabName") or CollapseTab("tabName") accordingly.