### PR TITLE
Updates for ClearValue, GetValue, and SetValue methods (Entity and BPF)

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api/Controls/DateTimeControl.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api/Controls/DateTimeControl.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using System;
+
+namespace Microsoft.Dynamics365.UIAutomation.Api
+{
+    /// <summary>
+    /// Represents a DateTime field in Dynamics 365.
+    /// </summary>
+    public class DateTimeControl
+    {
+        public string Name { get; set; }
+        public DateTime Value { get; set; }
+    }
+}

--- a/Microsoft.Dynamics365.UIAutomation.Api/Controls/TwoOption.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api/Controls/TwoOption.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+namespace Microsoft.Dynamics365.UIAutomation.Api
+{
+    /// <summary>
+    /// Represents a TwoOption or Checkbox field in Dynamics 365.
+    /// </summary>
+    public class TwoOption
+    {
+        public string Name { get; set; }
+        public string Value { get; set; }
+    }
+}

--- a/Microsoft.Dynamics365.UIAutomation.Api/DTOs/ElementReference.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api/DTOs/ElementReference.cs
@@ -25,6 +25,8 @@ namespace Microsoft.Dynamics365.UIAutomation.Api
             { "BPF_OptionSetFieldContainer"     , "//div[@id=\"header_process_[NAME]\"]" },
             { "BPF_LookupFieldContainer"     , "//div[@id=\"header_process_[NAME]\"]" },
             { "BPF_DateFieldContainer"     , "//div[@id=\"header_process_[NAME]\"]" },
+            { "BPF_DateFieldInput"     , "//input[@id=\"header_process_[NAME]_iDateInput\"]" },
+            { "BPF_GetLookupSearchIcon"     , "//div[@id=\"header_process_[NAME]_lookupSearchIconDiv\"]" },
 
             //Dialogs
             { "Dialog_Header"       , "id(\"dialogHeaderTitle\")"},
@@ -134,6 +136,13 @@ namespace Microsoft.Dynamics365.UIAutomation.Api
             { "Entity_SelectFormSection",  "id(\"FormSecNavigationControl-Icon\")"}, //GitHub Issue 56
             { "Entity_TabId"       , "//a/*[contains(text(),'[NAME]')]/parent::a"}, //GitHub Issue 124
             { "Entity_FieldContainer"       , "//div[contains(@id,'[NAME]')]"},
+            { "Entity_TextFieldContainer"     , "//div[@id=\"[NAME]\"]" },
+            { "Entity_CheckboxFieldContainer"     , "//div[@id=\"[NAME]\"]" },
+            { "Entity_OptionSetFieldContainer"     , "//div[@id=\"[NAME]\"]" },
+            { "Entity_LookupFieldContainer"     , "//div[@id=\"[NAME]\"]" },
+            { "Entity_DateFieldContainer"     , "//div[@id=\"[NAME]\"]" },
+            { "Entity_DateFieldInput"     , "//input[@id=\"[NAME]_iDateInput\"]" },
+            { "Entity_GetLookupSearchIcon"     , "//div[@id=\"[NAME]_lookupSearchIconDiv\"]" },
 
             //Related MenuItems
             { "Related_Popout",                 "//li[contains(@data-id,\"tablist-tab_related\")]" },
@@ -224,7 +233,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api
             { "LookUp_SavedQuerySelector", "id(\"crmGrid_SavedQuerySelector\")"},
             { "LookUp_DialogCancel", "id(\"cmdDialogCancel\")"},
             { "LookUp_New", "id(\"btnNew\")"},
-            { "LookUp_Remove", "id(\"btnRemove\")"},
+            { "LookUp_Remove", "id(\"btnRemoveValue\")"},
             { "LookUp_Add", "id(\"btnAdd\")"},
             { "LookUp_Begin", "id(\"butBegin\")"},
 
@@ -411,6 +420,8 @@ namespace Microsoft.Dynamics365.UIAutomation.Api
             public static string OptionSetFieldContainer = "BPF_OptionSetFieldContainer";
             public static string LookupFieldContainer = "BPF_LookupFieldContainer";
             public static string DateFieldContainer = "BPF_DateFieldContainer";
+            public static string DateFieldInput = "BPF_DateFieldInput";
+            public static string GetLookupSearchIcon = "BPF_GetLookupSearchIcon";
         }
 
         public static class Dialogs
@@ -611,6 +622,13 @@ namespace Microsoft.Dynamics365.UIAutomation.Api
             public static string LookupRender = "Entity_LookupRenderClass";
             public static string Popout = "Entity_PopoutClass";
             public static string FieldContainer = "Entity_FieldContainer";
+            public static string TextFieldContainer = "Entity_TextFieldContainer";
+            public static string CheckboxFieldContainer = "Entity_CheckboxFieldContainer";
+            public static string OptionSetFieldContainer = "Entity_OptionSetFieldContainer";
+            public static string LookupFieldContainer = "Entity_LookupFieldContainer";
+            public static string DateFieldContainer = "Entity_DateFieldContainer";
+            public static string DateFieldInput = "Entity_DateFieldInput";
+            public static string GetLookupSearchIcon = "Entity_GetLookupSearchIcon";
         }
         public static class MenuRelated
         {

--- a/Microsoft.Dynamics365.UIAutomation.Api/Microsoft.Dynamics365.UIAutomation.Api.csproj
+++ b/Microsoft.Dynamics365.UIAutomation.Api/Microsoft.Dynamics365.UIAutomation.Api.csproj
@@ -68,6 +68,8 @@
     <Compile Include="Controls\Field.cs" />
     <Compile Include="Controls\LookupItem.cs" />
     <Compile Include="Controls\MultiValueOptionSet.cs" />
+    <Compile Include="Controls\DateTimeControl.cs" />
+    <Compile Include="Controls\TwoOption.cs" />
     <Compile Include="Controls\OptionSet.cs" />
     <Compile Include="DTOs\PerformanceNavigationTiming.cs" />
     <Compile Include="DTOs\PerformanceResource.cs" />

--- a/Microsoft.Dynamics365.UIAutomation.Api/Pages/BusinessProcessFlow.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api/Pages/BusinessProcessFlow.cs
@@ -288,36 +288,28 @@ namespace Microsoft.Dynamics365.UIAutomation.Api
         /// <summary>
         /// Sets the value of a Checkbox/TwoOption field in a Business Process Flow.
         /// </summary>
-        /// <param name="field">Field schema name</param>
-        /// <param name="check">If set to <c>true</c> [check].</param>
-        /// <example>xrmBrowser.BusinessProcessFlow.SetValue("creditonhold",true);</example>
-        public new BrowserCommandResult<bool> SetValue(string field, bool check)
+        /// <param name="option">The TwoOption field you want to set</param>
+        /// <example>xrmBrowser.BusinessProcessFlow.SetValue(new TwoOption { Name = "creditonhold"});</example>
+        public new BrowserCommandResult<bool> SetValue(TwoOption option)
         {
-            return this.Execute(GetOptions($"Set Checkbox/TwoOption Value for BPF: {field}"), driver =>
+            return this.Execute(GetOptions($"Set Checkbox/TwoOption Value for BPF: {option.Name}"), driver =>
             {
-                if (driver.HasElement(By.XPath(Elements.Xpath[Reference.BusinessProcessFlow.CheckboxFieldContainer].Replace("[NAME]", field.ToLower()))))
+                if (driver.HasElement(By.XPath(Elements.Xpath[Reference.BusinessProcessFlow.CheckboxFieldContainer].Replace("[NAME]", option.Name.ToLower()))))
                 {
-                    var fieldElement = driver.WaitUntilAvailable(By.XPath(Elements.Xpath[Reference.BusinessProcessFlow.CheckboxFieldContainer].Replace("[NAME]", field.ToLower())));
+                    var fieldElement = driver.WaitUntilAvailable(By.XPath(Elements.Xpath[Reference.BusinessProcessFlow.CheckboxFieldContainer].Replace("[NAME]", option.Name.ToLower())));
 
                     if (fieldElement.FindElements(By.TagName("label")).Count > 0)
                     {
                         var label = fieldElement.FindElement(By.TagName("label"));
 
-                        if (label.Text == "mark complete" && check)
+                        if (label.Text != option.Value)
                         {
                             fieldElement.Click(true);
                         }
-                        else if (label.Text == "completed" && !check)
-                        {
-                            fieldElement.Click(true);
-                        }
-                        else
-                            // In this scenario (completed && check) || (mark complete && !check) => do nothing
-                            return true;
                     }
                 }
                 else
-                    throw new InvalidOperationException($"Unable to locate field '{field}' in the Business Process Flow. Please verify the field exists and try again.");
+                    throw new InvalidOperationException($"Unable to locate TwoOption field '{option.Name}' in the Business Process Flow. Please verify the TwoOption field exists and try again.");
 
                 return true;
             });
@@ -421,17 +413,16 @@ namespace Microsoft.Dynamics365.UIAutomation.Api
         /// <summary>
         /// Sets the value of a Date field in a Business Process Flow.
         /// </summary>
-        /// <param name="field">The field id or name.</param>
         /// <param name="date">DateTime value.</param>
-        /// <example> xrmBrowser.BusinessProcessFlow.SetValue("birthdate", DateTime.Parse("11/1/1980"));</example>
-        public new BrowserCommandResult<bool> SetValue(string field, DateTime date)
+        /// <example> xrmBrowser.BusinessProcessFlow.SetValue(new DateTime {Name = "birthdate", Value= DateTime.Parse("11/1/1980"}));</example>
+        public new BrowserCommandResult<bool> SetValue(DateTimeControl date)
         {
             //return this.Execute($"Set Value: {field}", SetValue, field, date);
-            return this.Execute(GetOptions($"Set Value: {field}"), driver =>
+            return this.Execute(GetOptions($"Set DateTime Value: {date.Name}"), driver =>
             {
-                if (driver.HasElement(By.XPath(Elements.Xpath[Reference.BusinessProcessFlow.DateFieldContainer].Replace("[NAME]", field.ToLower()))))
+                if (driver.HasElement(By.XPath(Elements.Xpath[Reference.BusinessProcessFlow.DateFieldContainer].Replace("[NAME]", date.Name.ToLower()))))
                 {
-                    var fieldElement = driver.ClickWhenAvailable(By.XPath(Elements.Xpath[Reference.BusinessProcessFlow.DateFieldContainer].Replace("[NAME]", field.ToLower())));
+                    var fieldElement = driver.ClickWhenAvailable(By.XPath(Elements.Xpath[Reference.BusinessProcessFlow.DateFieldContainer].Replace("[NAME]", date.Name.ToLower())));
 
                     //Check to see if focus is on field already
                     if (fieldElement.FindElement(By.ClassName(Elements.CssClass[Reference.SetValue.EditClass])) != null)
@@ -445,17 +436,17 @@ namespace Microsoft.Dynamics365.UIAutomation.Api
                     {
                         input.Clear();
                         fieldElement.Click();
-                        input.SendKeys(date.ToShortDateString());
+                        input.SendKeys(date.Value.ToShortDateString());
                         input.SendKeys(Keys.Enter);
                     }
                     else
                     {
-                        input.SendKeys(date.ToShortDateString());
+                        input.SendKeys(date.Value.ToShortDateString());
                         input.SendKeys(Keys.Enter);
                     }
                 }
                 else
-                    throw new InvalidOperationException($"Unable to locate Date field '{field}' in the Business Process Flow. Please verify the Date field exists and try again.");
+                    throw new InvalidOperationException($"Unable to locate DateTime field '{date.Name}' in the Business Process Flow. Please verify the DateTime field exists and try again.");
 
                 return true;
             });
@@ -563,6 +554,338 @@ namespace Microsoft.Dynamics365.UIAutomation.Api
         public new BrowserCommandResult<bool> SetValue(Field field)
         {
             return this.Execute(GetOptions($"Set Value: {field.Name}"), driver =>
+            {
+                /*
+                driver.WaitUntilVisible(By.Id(field.Id));
+
+                if (driver.HasElement(By.Id(field.Id)))
+                {
+                    var fieldElement = driver.ClickWhenAvailable(By.Id(field.Id));
+
+                    //Check to see if focus is on field already
+                    if (fieldElement.FindElement(By.ClassName(Elements.CssClass[Reference.SetValue.EditClass])) != null)
+                        fieldElement.FindElement(By.ClassName(Elements.CssClass[Reference.SetValue.EditClass])).Click();
+                    else
+                        fieldElement.FindElement(By.ClassName(Elements.CssClass[Reference.SetValue.ValueClass])).Click();
+
+
+                    if (fieldElement.FindElements(By.TagName("textarea")).Count > 0)
+                    {
+                        fieldElement.FindElement(By.TagName("textarea")).Clear();
+                        fieldElement.FindElement(By.TagName("textarea")).SendKeys(field.Value);
+                    }
+                    else
+                    {
+                        fieldElement.FindElement(By.TagName("input")).Clear();
+                        fieldElement.FindElement(By.TagName("input")).SendKeys(field.Value);
+                    }
+
+                }
+                else
+                    throw new InvalidOperationException($"Field: {field} Does not exist");
+                */
+                return true;
+            });
+        }
+
+        /// <summary>
+        /// Clears the value of a Text field in a Business Process Flow
+        /// </summary>
+        /// <param name="field">The field</param>
+        /// <param name="value">The value</param>
+        /// <example>xrmBrowser.BusinessProcessFlow.ClearValue("firstname", "Test");</example>
+        public new BrowserCommandResult<bool> ClearValue(string field)
+        {
+            return this.Execute(GetOptions($"Set Text field Value: {field}"), driver =>
+            {
+                if (driver.HasElement(By.XPath(Elements.Xpath[Reference.BusinessProcessFlow.TextFieldContainer].Replace("[NAME]", field.ToLower()))))
+                {
+                    var fieldElement = driver.WaitUntilAvailable(By.XPath(Elements.Xpath[Reference.BusinessProcessFlow.TextFieldContainer].Replace("[NAME]", field.ToLower())));
+
+                    fieldElement.Click();
+
+                    if (fieldElement.FindElements(By.TagName("textarea")).Count > 0)
+                    {
+                        fieldElement.FindElement(By.TagName("textarea")).Clear();
+                    }
+                    else if (fieldElement.TagName == "textarea")
+                    {
+                        fieldElement.Clear();
+                    }
+                }
+                else
+                    throw new InvalidOperationException($"Unable to locate field '{field}' in the Business Process Flow. Please verify the field exists and try again.");
+
+                return true;
+            });
+        }
+
+        /// <summary>
+        /// Clears the value of a Checkbox/TwoOption field in a Business Process Flow.
+        /// </summary>
+        /// <param name="option">The TwoOption field you want to set</param>
+        /// <example>xrmBrowser.BusinessProcessFlow.ClearValue(new TwoOption{ Name = "creditonhold"});</example>
+        public new BrowserCommandResult<bool> ClearValue(TwoOption option)
+        {
+            return this.Execute(GetOptions($"Clear Checkbox/TwoOption Value for BPF: {option.Name}"), driver =>
+            {
+                if (driver.HasElement(By.XPath(Elements.Xpath[Reference.BusinessProcessFlow.CheckboxFieldContainer].Replace("[NAME]", option.Name.ToLower()))))
+                {
+                    var fieldElement = driver.WaitUntilAvailable(By.XPath(Elements.Xpath[Reference.BusinessProcessFlow.CheckboxFieldContainer].Replace("[NAME]", option.Name.ToLower())));
+
+                    if (fieldElement.FindElements(By.TagName("label")).Count > 0)
+                    {
+                        var select = fieldElement;
+                        var label = fieldElement.FindElement(By.TagName("label")).Text;
+
+                        if (fieldElement.TagName != "select")
+                            select = fieldElement.FindElement(By.TagName("select"));
+
+                        var options = select.FindElements(By.TagName("option"));
+
+                        foreach (var op in options)
+                        {
+                            if (((op.Text.ToLower() != label.ToLower() || op.GetAttribute("title").ToLower() != label.ToLower()) && op.GetAttribute("value") == "0"))
+                            {
+                                fieldElement.Click(true);
+                            }
+                        }
+                    }                
+                }
+                else
+                    throw new InvalidOperationException($"Unable to locate TwoOption field '{option.Name}' in the Business Process Flow. Please verify the TwoOption field exists and try again.");
+
+                return true;
+            });
+        }
+
+        /// <summary>
+        /// Clears the value of an option set / picklist in a Business Process Flow.
+        /// </summary>
+        /// <param name="option">The option you want to clear.</param>
+        /// <example>xrmBrowser.BusinessProcessFlow.ClearValue(new OptionSet { Name = "preferredcontactmethodcode"});</example>
+        public new BrowserCommandResult<bool> ClearValue(OptionSet option)
+        {
+            return this.Execute(GetOptions($"Clear OptionSet Value for BPF: {option.Name}"), driver =>
+            {
+
+                if (driver.HasElement(By.XPath(Elements.Xpath[Reference.BusinessProcessFlow.OptionSetFieldContainer].Replace("[NAME]", option.Name.ToLower()))))
+                {
+                    var fieldElement = driver.WaitUntilAvailable(By.XPath(Elements.Xpath[Reference.BusinessProcessFlow.CheckboxFieldContainer].Replace("[NAME]", option.Name.ToLower())));
+                    var select = fieldElement;
+
+                    if (fieldElement.TagName != "select")
+                        select = fieldElement.FindElement(By.TagName("select"));
+
+                    var options = select.FindElements(By.TagName("option"));
+
+                    foreach (var op in options)
+                    {
+                        if (op.GetAttribute("value") == "")
+                        {
+                            fieldElement.Click(true);
+                            op.Click(true);
+                        }
+                    }
+                }
+                else
+                    throw new InvalidOperationException($"Unable to locate OptionSet '{option.Name}' in the Business Process Flow. Please verify the OptionSet exists and try again.");
+
+                return true;
+            });
+        }
+
+        /// <summary>
+        /// Clears the value of a Lookup in a Business Process Flow.
+        /// </summary>
+        /// <param name="control">The lookup field name, value or index of the lookup.</param>
+        /// <example>xrmBrowser.BusinessProcessFlow.ClearValue(new Lookup { Name = "prrimarycontactid", Value = "Rene Valdes (sample)" });</example>
+        public new BrowserCommandResult<bool> ClearValue(LookupItem control)
+        {
+            return this.Execute(GetOptions($"Clear Lookup Value in BPF: {control.Name}"), driver =>
+            {
+                if (driver.HasElement(By.XPath(Elements.Xpath[Reference.BusinessProcessFlow.LookupFieldContainer].Replace("[NAME]", control.Name.ToLower()))))
+                {
+                    var fieldElement = driver.WaitUntilAvailable(By.XPath(Elements.Xpath[Reference.BusinessProcessFlow.LookupFieldContainer].Replace("[NAME]", control.Name.ToLower())));
+
+                    if (fieldElement.Text != "")
+                    {
+                        fieldElement.Hover(driver, true);
+
+                        if (fieldElement.FindElement(By.XPath(Elements.Xpath[Reference.BusinessProcessFlow.GetLookupSearchIcon].Replace("[NAME]", control.Name.ToLower()))) == null)
+                            throw new InvalidOperationException($"Field: {control.Name} is not Lookup control");
+
+                        driver.Manage().Window.Maximize();
+                        var lookupSearch = driver.WaitUntilAvailable(By.XPath(Elements.Xpath[Reference.BusinessProcessFlow.GetLookupSearchIcon].Replace("[NAME]", control.Name.ToLower())));
+
+                        if (!lookupSearch.Displayed)
+                        {
+                            driver.Manage().Window.Minimize();
+                            driver.Manage().Window.Maximize();
+                            fieldElement.Hover(driver, true);
+                            lookupSearch = driver.WaitUntilAvailable(By.XPath(Elements.Xpath[Reference.BusinessProcessFlow.GetLookupSearchIcon].Replace("[NAME]", control.Name.ToLower())));
+                        }
+
+                        lookupSearch.Click(true);
+
+                        var dialogName = $"Dialog_header_process_{control.Name}_IMenu";
+                        var dialog = driver.WaitUntilAvailable(By.Id(dialogName));
+
+                        var dialogItems = OpenDialog(dialog).Value;
+
+                        if (dialogItems.Any())
+                        {
+                            var dialogItem = dialogItems.Last();
+                            dialogItem.Element.Click();
+                        }
+
+                        SwitchToDialog();
+
+                        driver.WaitUntilAvailable(By.XPath(Elements.Xpath[Reference.LookUp.Remove])).Click(true);
+
+                    }                  
+                }
+                else
+                    throw new InvalidOperationException($"Unable to locate Lookup '{control.Name}' in the Business Process Flow. Please verify the Lookup exists and try again.");
+
+                return true;
+            });
+        }
+
+        /// <summary>
+        /// Clears the value of a DateTime field in a Business Process Flow.
+        /// </summary>
+        /// <param name="date">DateTime value.</param>
+        /// <example> xrmBrowser.BusinessProcessFlow.ClearValue(new DateTime {Name = "birthdate"}));</example>
+        public new BrowserCommandResult<bool> ClearValue(DateTimeControl date)
+        {
+            //return this.Execute($"Set Value: {field}", SetValue, field, date);
+            return this.Execute(GetOptions($"Clear DateTime Field: {date.Name}"), driver =>
+            {
+                if (driver.HasElement(By.XPath(Elements.Xpath[Reference.BusinessProcessFlow.DateFieldContainer].Replace("[NAME]", date.Name.ToLower()))))
+                {
+                    var fieldElement = driver.WaitUntilAvailable(By.XPath(Elements.Xpath[Reference.BusinessProcessFlow.DateFieldContainer].Replace("[NAME]", date.Name.ToLower())));
+
+                    // Check whether the DateTime field has an existing value
+                    if (fieldElement.GetAttribute("title") != "Select to enter data")
+                    {
+                        fieldElement.Click(true);
+                        var fieldInput = driver.WaitUntilAvailable(By.XPath(Elements.Xpath[Reference.BusinessProcessFlow.DateFieldInput].Replace("[NAME]", date.Name.ToLower())));
+                        // Clear any existing values
+                        fieldInput.Clear();
+                        fieldElement.Click(true);
+                        fieldElement.SendKeys(Keys.Enter);
+                    }
+                }
+                else
+                    throw new InvalidOperationException($"Unable to locate DateTime field '{date.Name}' in the Business Process Flow. Please verify the DateTime field exists and try again.");
+
+                return true;
+            });
+        }
+
+        /// <summary>
+        /// Placeholder: MultiValueOptionSets are not currently supported in BPFs.
+        /// </summary>
+        /// <param name="option">The option you want to clear.</param>
+        /// <example>xrmBrowser.BusinessProcessFlow.ClearValue(new OptionSet { Name = "preferredcontactmethodcode"});</example>
+        public new BrowserCommandResult<bool> ClearValue(MultiValueOptionSet option, bool removeExistingValues = false)
+        {
+            return this.Execute(GetOptions($"Clear Value: {option.Name}"), driver =>
+            {
+
+                /*
+                driver.WaitUntilVisible(By.Id(option.Name));
+
+                if (driver.HasElement(By.Id(option.Name)))
+                {
+                    var container = driver.ClickWhenAvailable(By.Id(option.Name));
+
+                    if (removeExistingValues)
+                    {
+                        //Remove Existing Values
+                        var values = container.FindElements(By.ClassName(Elements.CssClass[Reference.SetValue.MultiSelectPicklistDeleteClass]));
+                        foreach (var value in values)
+                            value.Click(true);
+                    }
+
+                    var input = container.FindElement(By.TagName("input"));
+                    input.Click();
+                    input.SendKeys(" ");
+
+                    var options = container.FindElements(By.TagName("li"));
+
+                    foreach (var op in options)
+                    {
+                        var label = op.FindElement(By.TagName("label"));
+
+                        if (option.Values.Contains(op.Text) || option.Values.Contains(op.GetAttribute("value")) || option.Values.Contains(label.GetAttribute("title")))
+                            op.Click(true);
+                    }
+
+                    container.Click();
+                }
+                else
+                    throw new InvalidOperationException($"Field: {option.Name} Does not exist");
+
+                */
+
+                return true;
+            });
+        }
+
+        /// <summary>
+        /// Placeholder: CompositeControls are not currently supported in BPFs.
+        /// </summary>
+        /// <param name="control">The Composite control values you want to clear.</param>
+        /// <example>xrmBrowser.BusinessProcessFlow.ClearValue(new CompositeControl() {Id = "fullname"});</example>
+        public new BrowserCommandResult<bool> ClearValue(CompositeControl control)
+        {
+            return this.Execute(GetOptions($"Clear Conposite Control Value: {control.Id}"), driver =>
+            {
+                /*
+                driver.WaitUntilVisible(By.Id(control.Id));
+
+                if (!driver.HasElement(By.Id(control.Id)))
+                    return false;
+
+                driver.ClickWhenAvailable(By.Id(control.Id));
+
+                if (driver.HasElement(By.Id(control.Id + Elements.ElementId[Reference.SetValue.FlyOut])))
+                {
+                    var compcntrl =
+                        driver.FindElement(By.Id(control.Id + Elements.ElementId[Reference.SetValue.FlyOut]));
+
+                    foreach (var field in control.Fields)
+                    {
+                        compcntrl.FindElement(By.Id(control.Id + Elements.ElementId[Reference.SetValue.CompositionLinkControl] + field.Id)).Click();
+
+                        var result = compcntrl.FindElements(By.TagName("input"))
+                            .ToList()
+                            .FirstOrDefault(i => i.GetAttribute("id").Contains(field.Id));
+
+                        //BugFix - Setvalue -The value is getting erased even after setting the value ,might be due to recent CSS changes.
+                        driver.ExecuteScript("document.getElementById('" + result?.GetAttribute("id") + "').value = ''");
+                        result?.SendKeys(field.Value);
+                    }
+
+                    compcntrl.FindElement(By.Id(control.Id + Elements.ElementId[Reference.SetValue.Confirm])).Click();
+                }
+                else
+                    throw new InvalidOperationException($"Composite Control: {control.Id} Does not exist");
+
+                */
+                return true;
+            });
+        }
+
+        /// <summary>
+        /// Placeholder: Clears the value of a Field.
+        /// </summary>
+        /// <param name="field">The field .</param>
+        public new BrowserCommandResult<bool> ClearValue(Field field)
+        {
+            return this.Execute(GetOptions($"Clear Value: {field.Name}"), driver =>
             {
                 /*
                 driver.WaitUntilVisible(By.Id(field.Id));
@@ -763,19 +1086,21 @@ namespace Microsoft.Dynamics365.UIAutomation.Api
         /// <summary>
         /// Gets the value of a Checkbox/TwoOption field in a Business Process Flow.
         /// </summary>
-        /// <param name="field">Field schema name</param>
-        /// <param name="check">If set to <c>true</c> [check].</param>
-        /// <example>xrmBrowser.BusinessProcessFlow.GetValue("creditonhold",true);</example>
-        public new BrowserCommandResult<bool> GetValue(string field, bool check)
+        /// <param name="option">The TwoOption field you want to set</param>
+        /// <example>xrmBrowser.BusinessProcessFlow.GetValue(new TwoOption {Name="creditonhold"});</example>
+        public new BrowserCommandResult<bool> GetValue(TwoOption option)
         {
 
-            return this.Execute(GetOptions($"Get Checkbox/TwoOption Value for BPF: {field}"), driver =>
+            return this.Execute(GetOptions($"Get Checkbox/TwoOption Value for BPF: {option.Name}"), driver =>
             {
-                if (driver.HasElement(By.XPath(Elements.Xpath[Reference.BusinessProcessFlow.CheckboxFieldContainer].Replace("[NAME]", field.ToLower()))))
+                bool check = false;
+
+                if (driver.HasElement(By.XPath(Elements.Xpath[Reference.BusinessProcessFlow.CheckboxFieldContainer].Replace("[NAME]", option.Name.ToLower()))))
                 {
-                    var fieldElement = driver.WaitUntilAvailable(By.XPath(Elements.Xpath[Reference.BusinessProcessFlow.CheckboxFieldContainer].Replace("[NAME]", field.ToLower())));
+                    var fieldElement = driver.WaitUntilAvailable(By.XPath(Elements.Xpath[Reference.BusinessProcessFlow.CheckboxFieldContainer].Replace("[NAME]", option.Name.ToLower())));
                     var select = fieldElement;
                     var text = "";
+
 
                     if (fieldElement.FindElements(By.TagName("label")).Count > 0)
                     {
@@ -799,9 +1124,39 @@ namespace Microsoft.Dynamics365.UIAutomation.Api
                     }
                 }
                 else
-                    throw new InvalidOperationException($"Unable to locate field '{field}' in the Business Process Flow. Please verify the field exists and try again.");
+                    throw new InvalidOperationException($"Unable to locate TwoOption field '{option.Name}' in the Business Process Flow. Please verify the TwoOption field exists and try again.");
 
                 return check;
+            });
+        }
+
+        /// <summary>
+        /// Gets the value of a DateTime field in a Business Process Flow.
+        /// </summary>
+        /// <param name="date">DateTime value.</param>
+        /// <example> xrmBrowser.BusinessProcessFlow.GetValue(new DateTime {Name = "birthdate"));</example>
+        public new BrowserCommandResult<string> GetValue(DateTimeControl date)
+        {
+            //return this.Execute($"Set Value: {field}", SetValue, field, date);
+            return this.Execute(GetOptions($"Get DateTime Value: {date.Name}"), driver =>
+            {
+                string dateValue = "";
+                if (driver.HasElement(By.XPath(Elements.Xpath[Reference.BusinessProcessFlow.DateFieldContainer].Replace("[NAME]", date.Name.ToLower()))))
+                {
+
+                    var fieldElement = driver.WaitUntilAvailable(By.XPath(Elements.Xpath[Reference.BusinessProcessFlow.DateFieldContainer].Replace("[NAME]", date.Name.ToLower())));
+
+                    // Check whether the DateTime field has an existing value
+                    if (fieldElement.FindElements(By.TagName("label")).Count > 0)
+                    {
+                        var label = fieldElement.FindElement(By.TagName("label"));
+                        dateValue = label.Text;
+                    }
+                }
+                else
+                    throw new InvalidOperationException($"Unable to locate DateTime field '{date.Name}' in the Business Process Flow. Please verify the DateTime field exists and try again.");
+
+                return dateValue;
             });
         }
 

--- a/Microsoft.Dynamics365.UIAutomation.Api/XrmPage.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api/XrmPage.cs
@@ -543,16 +543,16 @@ namespace Microsoft.Dynamics365.UIAutomation.Api
                 if (driver.HasElement(By.Id(control.Id + Elements.ElementId[Reference.SetValue.FlyOut])))
                 {
                     var compcntrl =
-                        driver.FindElement(By.Id(control.Id + Elements.ElementId[Reference.SetValue.FlyOut]));
+                        driver.WaitUntilAvailable(By.Id(control.Id + Elements.ElementId[Reference.SetValue.FlyOut]));
 
                     foreach (var field in control.Fields)
                     {
-                        compcntrl.FindElement(By.Id(Elements.ElementId[Reference.SetValue.CompositionLinkControl] + field.Id)).Click();
+                        compcntrl.FindElement(By.Id(control.Id + Elements.ElementId[Reference.SetValue.CompositionLinkControl] + field.Id)).Click(true);
 
                         var result = compcntrl.FindElements(By.TagName("input"))
                             .ToList()
                             .FirstOrDefault(i => i.GetAttribute("id").Contains(field.Id));
-                        text += result.GetAttribute("value");
+                        text += result.GetAttribute("value") + " ";
                     }
 
                     compcntrl.FindElement(By.Id(control.Id + Elements.ElementId[Reference.SetValue.Confirm])).Click();
@@ -560,7 +560,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api
                 else
                     throw new InvalidOperationException($"Composite Control: {control.Id} Does not exist");
 
-                return text;
+                return text.TrimEnd(' ');
             });
         }
 
@@ -939,8 +939,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api
         public BrowserCommandResult<bool> ClearValue(CompositeControl control)
         {
             return this.Execute(GetOptions($"Clear Conposite Control Value: {control.Id}"), driver =>
-            {
-                /*
+            {                
                 driver.WaitUntilVisible(By.Id(control.Id));
 
                 if (!driver.HasElement(By.Id(control.Id)))
@@ -955,23 +954,27 @@ namespace Microsoft.Dynamics365.UIAutomation.Api
 
                     foreach (var field in control.Fields)
                     {
-                        compcntrl.FindElement(By.Id(control.Id + Elements.ElementId[Reference.SetValue.CompositionLinkControl] + field.Id)).Click();
+                        compcntrl.FindElement(By.Id(control.Id + Elements.ElementId[Reference.SetValue.CompositionLinkControl] + field.Id)).Click(true);
 
                         var result = compcntrl.FindElements(By.TagName("input"))
                             .ToList()
                             .FirstOrDefault(i => i.GetAttribute("id").Contains(field.Id));
 
-                        //BugFix - Setvalue -The value is getting erased even after setting the value ,might be due to recent CSS changes.
-                        driver.ExecuteScript("document.getElementById('" + result?.GetAttribute("id") + "').value = ''");
-                        result?.SendKeys(field.Value);
+                        result?.Clear();
+                        result?.SendKeys(Keys.Tab);
+
+                        if (compcntrl.IsVisible(By.Id(control.Id + Elements.ElementId[Reference.SetValue.CompositionLinkControl] + field.Id + "_warnSpan")))
+                        {
+                            throw new InvalidOperationException($"The field {field.Id} has displayed a warning and cannot be cleared.");
+                        }
                     }
 
                     compcntrl.FindElement(By.Id(control.Id + Elements.ElementId[Reference.SetValue.Confirm])).Click();
+
                 }
                 else
                     throw new InvalidOperationException($"Composite Control: {control.Id} Does not exist");
-
-                */
+                
                 return true;
             });
         }

--- a/Microsoft.Dynamics365.UIAutomation.Api/XrmPage.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api/XrmPage.cs
@@ -63,25 +63,19 @@ namespace Microsoft.Dynamics365.UIAutomation.Api
         /// <example>xrmBrowser.Entity.SetValue(new TwoOption{ Name = "creditonhold"});</example>
         public BrowserCommandResult<bool> SetValue(TwoOption option)
         {
-            //return this.Execute($"Set Value: {field}", SetValue, field, check);
             return this.Execute(GetOptions($"Set TwoOption Value: {option.Name}"), driver =>
             {
                 if (driver.HasElement(By.XPath(Elements.Xpath[Reference.Entity.OptionSetFieldContainer].Replace("[NAME]", option.Name.ToLower()))))
                 {
                     var fieldElement = driver.WaitUntilAvailable(By.XPath(Elements.Xpath[Reference.Entity.CheckboxFieldContainer].Replace("[NAME]", option.Name.ToLower())));
-                    var select = fieldElement;
 
-                    if (fieldElement.TagName != "select")
-                        select = fieldElement.FindElement(By.TagName("select"));
-
-                    var options = select.FindElements(By.TagName("option"));
-
-                    foreach (var op in options)
+                    if (fieldElement.FindElements(By.TagName("label")).Count > 0)
                     {
-                        if (op.Text.ToLower() == option.Value.ToLower() || op.GetAttribute("title").ToLower() == option.Value.ToLower())
+                        var label = fieldElement.FindElement(By.TagName("label"));
+
+                        if (label.Text != option.Value)
                         {
                             fieldElement.Click(true);
-                            op.Click(true);
                         }
                     }
                 }
@@ -222,12 +216,14 @@ namespace Microsoft.Dynamics365.UIAutomation.Api
                     {
                         fieldElement.Clear();
                         fieldElement.SendKeys(value);
+                        fieldElement.SendKeys(Keys.Tab);
                     }
                     else
                     {
                         //BugFix - Setvalue -The value is getting erased even after setting the value ,might be due to recent CSS changes.
                         //driver.ExecuteScript("Xrm.Page.getAttribute('" + field + "').setValue('')");
                         fieldElement.FindElement(By.TagName("input")).SendKeys(value, true);
+                        fieldElement.SendKeys(Keys.Tab);
                     }
                 }
                 else
@@ -704,11 +700,11 @@ namespace Microsoft.Dynamics365.UIAutomation.Api
                 {
                     var fieldElement = driver.WaitUntilAvailable(By.XPath(Elements.Xpath[Reference.Entity.TextFieldContainer].Replace("[NAME]", field.ToLower())));
 
-                    fieldElement.Click();
+                    fieldElement.Click(true);
 
-                    if (fieldElement.FindElements(By.TagName("textarea")).Count > 0)
+                    if (fieldElement.FindElements(By.TagName("input")).Count > 0)
                     {
-                        fieldElement.FindElement(By.TagName("textarea")).Clear();
+                        fieldElement.FindElement(By.TagName("input")).Clear();
                     }
                     else if (fieldElement.TagName == "textarea")
                     {
@@ -830,7 +826,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api
 
                         lookupSearch.Click(true);
 
-                        var dialogName = $"Dialog_header_process_{control.Name}_IMenu";
+                        var dialogName = $"Dialog_{control.Name}_IMenu";
                         var dialog = driver.WaitUntilAvailable(By.Id(dialogName));
 
                         var dialogItems = OpenDialog(dialog).Value;

--- a/Microsoft.Dynamics365.UIAutomation.Api/XrmPage.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api/XrmPage.cs
@@ -27,7 +27,8 @@ namespace Microsoft.Dynamics365.UIAutomation.Api
         }
 
         /// <summary>
-        /// Sets the value of a Checkbox field.
+        /// DEPRECATED: Sets the value of a Checkbox field.
+        /// Please use the new TwoOption method ==> SetValue(TwoOption option)
         /// </summary>
         /// <param name="field">Field name or ID.</param>
         /// <param name="check">If set to <c>true</c> [check].</param>
@@ -56,7 +57,44 @@ namespace Microsoft.Dynamics365.UIAutomation.Api
         }
 
         /// <summary>
-        /// Sets the value of a Date Field.
+        /// Sets the value of a TwoOption / Checkbox field on an Entity form.
+        /// </summary>
+        /// <param name="option">Field name or ID.</param>
+        /// <example>xrmBrowser.Entity.SetValue(new TwoOption{ Name = "creditonhold"});</example>
+        public BrowserCommandResult<bool> SetValue(TwoOption option)
+        {
+            //return this.Execute($"Set Value: {field}", SetValue, field, check);
+            return this.Execute(GetOptions($"Set TwoOption Value: {option.Name}"), driver =>
+            {
+                if (driver.HasElement(By.XPath(Elements.Xpath[Reference.Entity.OptionSetFieldContainer].Replace("[NAME]", option.Name.ToLower()))))
+                {
+                    var fieldElement = driver.WaitUntilAvailable(By.XPath(Elements.Xpath[Reference.Entity.CheckboxFieldContainer].Replace("[NAME]", option.Name.ToLower())));
+                    var select = fieldElement;
+
+                    if (fieldElement.TagName != "select")
+                        select = fieldElement.FindElement(By.TagName("select"));
+
+                    var options = select.FindElements(By.TagName("option"));
+
+                    foreach (var op in options)
+                    {
+                        if (op.Text.ToLower() == option.Value.ToLower() || op.GetAttribute("title").ToLower() == option.Value.ToLower())
+                        {
+                            fieldElement.Click(true);
+                            op.Click(true);
+                        }
+                    }
+                }
+                else
+                    throw new InvalidOperationException($"Field: {option.Name} Does not exist");
+
+                return true;
+            });
+        }
+
+        /// <summary>
+        /// DEPRECATED: Sets the value of a Date Field.
+        /// Please use the new DateTimeControl method ==> SetValue(DateTimeControl date)
         /// </summary>
         /// <param name="field">The field id or name.</param>
         /// <param name="date">DateTime value.</param>
@@ -99,7 +137,50 @@ namespace Microsoft.Dynamics365.UIAutomation.Api
         }
 
         /// <summary>
-        /// Sets the value of a Text/Description field.
+        /// Sets the value of a Date Field on an Entity form.
+        /// </summary>
+        /// <param name="field">The field id or name.</param>
+        /// <param name="date">DateTime value.</param>
+        /// <example> xrmBrowser.Entity.SetValue(new DateTimeControl { Name = "birthdate", Value =  DateTime.Parse("11/1/1980")});</example>
+        public BrowserCommandResult<bool> SetValue(DateTimeControl date)
+        {
+            //return this.Execute($"Set Value: {field}", SetValue, field, date);
+            return this.Execute(GetOptions($"Set DateTime Value: {date.Name}"), driver =>
+            {
+                if (driver.HasElement(By.Id(date.Name)))
+                {
+                    var fieldElement = driver.ClickWhenAvailable(By.Id(date.Name));
+
+                    //Check to see if focus is on field already
+                    if (fieldElement.FindElement(By.ClassName(Elements.CssClass[Reference.SetValue.EditClass])) != null)
+                        fieldElement.FindElement(By.ClassName(Elements.CssClass[Reference.SetValue.EditClass])).Click();
+                    else
+                        fieldElement.FindElement(By.ClassName(Elements.CssClass[Reference.SetValue.ValueClass])).Click();
+
+                    var input = fieldElement.FindElement(By.TagName("input"));
+
+                    if (input.GetAttribute("value").Length > 0)
+                    {
+                        input.Clear();
+                        fieldElement.Click();
+                        input.SendKeys(date.Value.ToShortDateString());
+                        input.SendKeys(Keys.Enter);
+                    }
+                    else
+                    {
+                        input.SendKeys(date.Value.ToShortDateString());
+                        input.SendKeys(Keys.Enter);
+                    }
+                }
+                else
+                    throw new InvalidOperationException($"Field: {date.Name} Does not exist");
+
+                return true;
+            });
+        }
+
+        /// <summary>
+        /// Sets the value of a Text/Description field on an Entity form.
         /// </summary>
         /// <param name="field">The field id.</param>
         /// <param name="value">The value.</param>
@@ -158,7 +239,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api
         }
 
         /// <summary>
-        /// Sets the value of a Field.
+        /// Sets the value of a Field on an Entity form.
         /// </summary>
         /// <param name="field">The field .</param>
         public BrowserCommandResult<bool> SetValue(Field field)
@@ -198,7 +279,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api
         }
 
         /// <summary>
-        /// Sets the value of a picklist.
+        /// Sets the value of a picklist on an Entity form.
         /// </summary>
         /// <param name="option">The option you want to set.</param>
         /// <example>xrmBrowser.Entity.SetValue(new OptionSet { Name = "preferredcontactmethodcode", Value = "Email" });</example>
@@ -232,7 +313,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api
         }
 
         /// <summary>
-        /// Sets the value of a multi-value picklist.
+        /// Sets the value of a multi-value picklist on an Entity form.
         /// </summary>
         /// <param name="option">The option you want to set.</param>
         /// <example>xrmBrowser.Entity.SetValue(new OptionSet { Name = "preferredcontactmethodcode", Value = "Email" });</example>
@@ -278,7 +359,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api
         }
 
         /// <summary>
-        /// Sets the value of a Composite control.
+        /// Sets the value of a Composite control on an Entity form.
         /// </summary>
         /// <param name="control">The Composite control values you want to set.</param>
         /// <example>xrmBrowser.Entity.SetValue(new CompositeControl() {Id = "fullname", Fields = fields});</example>
@@ -321,7 +402,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api
         }
 
         /// <summary>
-        /// Sets the value of a Lookup.
+        /// Sets the value of a Lookup on an Entity form.
         /// </summary>
         /// <param name="control">The lookup field name, value or index of the lookup.</param>
         /// <example>xrmBrowser.Entity.SetValue(new Lookup { Name = "prrimarycontactid", Value = "Rene Valdes (sample)" });</example>
@@ -373,7 +454,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api
         }
 
         /// <summary>
-        /// Gets the value of a Text/Description field.
+        /// Gets the value of a Text/Description field on an Entity form.
         /// </summary>
         /// <param name="field">The field id.</param>
         /// <returns>The value</returns>
@@ -408,7 +489,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api
         }
 
         /// <summary>
-        /// Gets the value of a Field.
+        /// Gets the value of a Field on an Entity form.
         /// </summary>
         /// <param name="field">The field .</param>
         /// <returns>The value</returns>
@@ -488,7 +569,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api
         }
 
         /// <summary>
-        /// Gets the value of a picklist.
+        /// Gets the value of a picklist on an Entity form
         /// </summary>
         /// <param name="option">The option you want to set.</param>
         /// <example>xrmBrowser.Entity.GetValue(new OptionSet { Name = "preferredcontactmethodcode"}); </example>
@@ -511,7 +592,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api
         }
 
         /// <summary>
-        /// Gets the value of a Lookup.
+        /// Gets the value of a Lookup on an Entity form.
         /// </summary>
         /// <param name="control">The lookup field name, value or index of the lookup.</param>
         /// <example>xrmBrowser.Entity.GetValue(new Lookup { Name = "primarycontactid" });</example>
@@ -531,6 +612,412 @@ namespace Microsoft.Dynamics365.UIAutomation.Api
                     throw new InvalidOperationException($"Field: {control.Name} Does not exist");
 
                 return lookupValue;
+            });
+        }
+
+        /// <summary>
+        /// Gets the value of a DateTime field on an entity form.
+        /// </summary>
+        /// <param name="date">DateTime value.</param>
+        /// <example> xrmBrowser.Entity.GetValue(new DateTime {Name = "birthdate"));</example>
+        public BrowserCommandResult<string> GetValue(DateTimeControl date)
+        {
+            //return this.Execute($"Set Value: {field}", SetValue, field, date);
+            return this.Execute(GetOptions($"Get DateTime Value: {date.Name}"), driver =>
+            {
+                string dateValue = "";
+                if (driver.HasElement(By.XPath(Elements.Xpath[Reference.Entity.DateFieldContainer].Replace("[NAME]", date.Name.ToLower()))))
+                {
+
+                    var fieldElement = driver.WaitUntilAvailable(By.XPath(Elements.Xpath[Reference.Entity.DateFieldContainer].Replace("[NAME]", date.Name.ToLower())));
+
+                    // Check whether the DateTime field has an existing value
+                    if (fieldElement.FindElements(By.TagName("label")).Count > 0)
+                    {
+                        var label = fieldElement.FindElement(By.TagName("label"));
+                        dateValue = label.Text;
+                    }
+                }
+                else
+                    throw new InvalidOperationException($"Unable to locate DateTime field '{date.Name}' in the Business Process Flow. Please verify the DateTime field exists and try again.");
+
+                return dateValue;
+            });
+        }
+
+        /// <summary>
+        /// Gets the value of a Checkbox/TwoOption field in an Entity form.
+        /// </summary>
+        /// <param name="option">The TwoOption field you want to set</param>
+        /// <example>xrmBrowser.Entity.GetValue(new TwoOption {Name="creditonhold"});</example>
+        public BrowserCommandResult<bool> GetValue(TwoOption option)
+        {
+            return this.Execute(GetOptions($"Get Checkbox/TwoOption Value on an Entity form: {option.Name}"), driver =>
+            {
+                bool check = false;
+
+                if (driver.HasElement(By.XPath(Elements.Xpath[Reference.Entity.CheckboxFieldContainer].Replace("[NAME]", option.Name.ToLower()))))
+                {
+                    var fieldElement = driver.WaitUntilAvailable(By.XPath(Elements.Xpath[Reference.Entity.CheckboxFieldContainer].Replace("[NAME]", option.Name.ToLower())));
+                    var select = fieldElement;
+                    var text = "";
+
+
+                    if (fieldElement.FindElements(By.TagName("label")).Count > 0)
+                    {
+                        var label = fieldElement.FindElement(By.TagName("label"));
+                        text = label.Text;
+                    }
+
+                    if (fieldElement.TagName != "select")
+                        select = fieldElement.FindElement(By.TagName("select"));
+
+                    var options = select.FindElements(By.TagName("option"));
+
+                    foreach (var op in options)
+                    {
+                        if (op.Text.ToLower() == text.ToLower() || op.GetAttribute("title").ToLower() == text.ToLower())
+                        {
+                            var value = Convert.ToInt32(op.GetAttribute("value"));
+
+                            check = Convert.ToBoolean(value);
+                        }
+                    }
+                }
+                else
+                    throw new InvalidOperationException($"Unable to locate TwoOption field '{option.Name}' on the form. Please verify the TwoOption field exists and try again.");
+
+                return check;
+            });
+        }
+
+        /// <summary>
+        /// Clears the value of a Text field on an Entity form
+        /// </summary>
+        /// <param name="field">The field</param>
+        /// <example>xrmBrowser.Entity.ClearValue("firstname", "Test");</example>
+        public BrowserCommandResult<bool> ClearValue(string field)
+        {
+            return this.Execute(GetOptions($"Set Text field Value: {field}"), driver =>
+            {
+                if (driver.HasElement(By.XPath(Elements.Xpath[Reference.Entity.TextFieldContainer].Replace("[NAME]", field.ToLower()))))
+                {
+                    var fieldElement = driver.WaitUntilAvailable(By.XPath(Elements.Xpath[Reference.Entity.TextFieldContainer].Replace("[NAME]", field.ToLower())));
+
+                    fieldElement.Click();
+
+                    if (fieldElement.FindElements(By.TagName("textarea")).Count > 0)
+                    {
+                        fieldElement.FindElement(By.TagName("textarea")).Clear();
+                    }
+                    else if (fieldElement.TagName == "textarea")
+                    {
+                        fieldElement.Clear();
+                    }
+                }
+                else
+                    throw new InvalidOperationException($"Unable to locate field '{field}' on the form. Please verify the field exists and try again.");
+
+                return true;
+            });
+        }
+
+        /// <summary>
+        /// Clears the value of a Checkbox/TwoOption field on an Entity form
+        /// </summary>
+        /// <param name="option">The TwoOption field you want to set</param>
+        /// <example>xrmBrowser.Entity.ClearValue(new TwoOption{ Name = "creditonhold"});</example>
+        public BrowserCommandResult<bool> ClearValue(TwoOption option)
+        {
+            return this.Execute(GetOptions($"Clear Checkbox/TwoOption Value: {option.Name}"), driver =>
+            {
+                if (driver.HasElement(By.XPath(Elements.Xpath[Reference.Entity.CheckboxFieldContainer].Replace("[NAME]", option.Name.ToLower()))))
+                {
+                    var fieldElement = driver.WaitUntilAvailable(By.XPath(Elements.Xpath[Reference.Entity.CheckboxFieldContainer].Replace("[NAME]", option.Name.ToLower())));
+
+                    if (fieldElement.FindElements(By.TagName("label")).Count > 0)
+                    {
+                        var select = fieldElement;
+                        var label = fieldElement.FindElement(By.TagName("label")).Text;
+
+                        if (fieldElement.TagName != "select")
+                            select = fieldElement.FindElement(By.TagName("select"));
+
+                        var options = select.FindElements(By.TagName("option"));
+
+                        foreach (var op in options)
+                        {
+                            if (((op.Text.ToLower() != label.ToLower() || op.GetAttribute("title").ToLower() != label.ToLower()) && op.GetAttribute("value") == "0"))
+                            {
+                                fieldElement.Click(true);
+                            }
+                        }
+                    }
+                }
+                else
+                    throw new InvalidOperationException($"Unable to locate TwoOption field '{option.Name}' on the form. Please verify the TwoOption field exists and try again.");
+
+                return true;
+            });
+        }
+
+        /// <summary>
+        /// Clears the value of an option set / picklist on an Entity form
+        /// </summary>
+        /// <param name="option">The option you want to clear.</param>
+        /// <example>xrmBrowser.Entity.ClearValue(new OptionSet { Name = "preferredcontactmethodcode"});</example>
+        public BrowserCommandResult<bool> ClearValue(OptionSet option)
+        {
+            return this.Execute(GetOptions($"Clear OptionSet Value: {option.Name}"), driver =>
+            {
+
+                if (driver.HasElement(By.XPath(Elements.Xpath[Reference.Entity.OptionSetFieldContainer].Replace("[NAME]", option.Name.ToLower()))))
+                {
+                    var fieldElement = driver.WaitUntilAvailable(By.XPath(Elements.Xpath[Reference.Entity.CheckboxFieldContainer].Replace("[NAME]", option.Name.ToLower())));
+                    var select = fieldElement;
+
+                    if (fieldElement.TagName != "select")
+                        select = fieldElement.FindElement(By.TagName("select"));
+
+                    var options = select.FindElements(By.TagName("option"));
+
+                    foreach (var op in options)
+                    {
+                        if (op.GetAttribute("value") == "")
+                        {
+                            fieldElement.Click(true);
+                            op.Click(true);
+                        }
+                    }
+                }
+                else
+                    throw new InvalidOperationException($"Unable to locate OptionSet '{option.Name}' on the form. Please verify the OptionSet exists and try again.");
+
+                return true;
+            });
+        }
+
+        /// <summary>
+        /// Clears the value of a Lookup on an Entity form
+        /// </summary>
+        /// <param name="control">The lookup field name, value or index of the lookup.</param>
+        /// <example>xrmBrowser.Entity.ClearValue(new Lookup { Name = "prrimarycontactid", Value = "Rene Valdes (sample)" });</example>
+        public BrowserCommandResult<bool> ClearValue(LookupItem control)
+        {
+            return this.Execute(GetOptions($"Clear Lookup Value: {control.Name}"), driver =>
+            {
+                if (driver.HasElement(By.XPath(Elements.Xpath[Reference.Entity.LookupFieldContainer].Replace("[NAME]", control.Name.ToLower()))))
+                {
+                    var fieldElement = driver.WaitUntilAvailable(By.XPath(Elements.Xpath[Reference.Entity.LookupFieldContainer].Replace("[NAME]", control.Name.ToLower())));
+
+                    if (fieldElement.Text != "")
+                    {
+                        fieldElement.Hover(driver, true);
+
+                        if (fieldElement.FindElement(By.XPath(Elements.Xpath[Reference.Entity.GetLookupSearchIcon].Replace("[NAME]", control.Name.ToLower()))) == null)
+                            throw new InvalidOperationException($"Field: {control.Name} is not Lookup control");
+
+                        driver.Manage().Window.Maximize();
+                        var lookupSearch = driver.WaitUntilAvailable(By.XPath(Elements.Xpath[Reference.Entity.GetLookupSearchIcon].Replace("[NAME]", control.Name.ToLower())));
+
+                        if (!lookupSearch.Displayed)
+                        {
+                            driver.Manage().Window.Minimize();
+                            driver.Manage().Window.Maximize();
+                            fieldElement.Hover(driver, true);
+                            lookupSearch = driver.WaitUntilAvailable(By.XPath(Elements.Xpath[Reference.Entity.GetLookupSearchIcon].Replace("[NAME]", control.Name.ToLower())));
+                        }
+
+                        lookupSearch.Click(true);
+
+                        var dialogName = $"Dialog_header_process_{control.Name}_IMenu";
+                        var dialog = driver.WaitUntilAvailable(By.Id(dialogName));
+
+                        var dialogItems = OpenDialog(dialog).Value;
+
+                        if (dialogItems.Any())
+                        {
+                            var dialogItem = dialogItems.Last();
+                            dialogItem.Element.Click();
+                        }
+
+                        SwitchToDialog();
+
+                        driver.WaitUntilAvailable(By.XPath(Elements.Xpath[Reference.LookUp.Remove])).Click(true);
+
+                    }
+                }
+                else
+                    throw new InvalidOperationException($"Unable to locate Lookup '{control.Name}' on the form. Please verify the Lookup exists and try again.");
+
+                return true;
+            });
+        }
+
+        /// <summary>
+        /// Clears the value of a DateTime field on an Entity form.
+        /// </summary>
+        /// <param name="date">DateTime value.</param>
+        /// <example> xrmBrowser.Entity.ClearValue(new DateTime {Name = "birthdate"}));</example>
+        public BrowserCommandResult<bool> ClearValue(DateTimeControl date)
+        {
+            return this.Execute(GetOptions($"Clear DateTime Field: {date.Name}"), driver =>
+            {
+                if (driver.HasElement(By.XPath(Elements.Xpath[Reference.Entity.DateFieldContainer].Replace("[NAME]", date.Name.ToLower()))))
+                {
+                    var fieldElement = driver.WaitUntilAvailable(By.XPath(Elements.Xpath[Reference.Entity.DateFieldContainer].Replace("[NAME]", date.Name.ToLower())));
+
+                    // Check whether the DateTime field has an existing value
+                    if (fieldElement.GetAttribute("title") != "Select to enter data")
+                    {
+                        fieldElement.Click(true);
+                        var fieldInput = driver.WaitUntilAvailable(By.XPath(Elements.Xpath[Reference.Entity.DateFieldInput].Replace("[NAME]", date.Name.ToLower())));
+                        // Clear any existing values
+                        fieldInput.Clear();
+                        fieldElement.Click(true);
+                        fieldElement.SendKeys(Keys.Enter);
+                    }
+                }
+                else
+                    throw new InvalidOperationException($"Unable to locate DateTime field '{date.Name}' on the form. Please verify the DateTime field exists and try again.");
+
+                return true;
+            });
+        }
+
+        /// <summary>
+        /// Placeholder: MultiValueOptionSets are not currently supported in BPFs.
+        /// </summary>
+        /// <param name="option">The option you want to clear.</param>
+        /// <example>xrmBrowser.Entity.ClearValue(new OptionSet { Name = "preferredcontactmethodcode"});</example>
+        public BrowserCommandResult<bool> ClearValue(MultiValueOptionSet option, bool removeExistingValues = false)
+        {
+            return this.Execute(GetOptions($"Clear Value: {option.Name}"), driver =>
+            {
+
+                /*
+                driver.WaitUntilVisible(By.Id(option.Name));
+
+                if (driver.HasElement(By.Id(option.Name)))
+                {
+                    var container = driver.ClickWhenAvailable(By.Id(option.Name));
+
+                    if (removeExistingValues)
+                    {
+                        //Remove Existing Values
+                        var values = container.FindElements(By.ClassName(Elements.CssClass[Reference.SetValue.MultiSelectPicklistDeleteClass]));
+                        foreach (var value in values)
+                            value.Click(true);
+                    }
+
+                    var input = container.FindElement(By.TagName("input"));
+                    input.Click();
+                    input.SendKeys(" ");
+
+                    var options = container.FindElements(By.TagName("li"));
+
+                    foreach (var op in options)
+                    {
+                        var label = op.FindElement(By.TagName("label"));
+
+                        if (option.Values.Contains(op.Text) || option.Values.Contains(op.GetAttribute("value")) || option.Values.Contains(label.GetAttribute("title")))
+                            op.Click(true);
+                    }
+
+                    container.Click();
+                }
+                else
+                    throw new InvalidOperationException($"Field: {option.Name} Does not exist");
+
+                */
+
+                return true;
+            });
+        }
+
+        /// <summary>
+        /// Placeholder: CompositeControls are not currently supported in BPFs.
+        /// </summary>
+        /// <param name="control">The Composite control values you want to clear.</param>
+        /// <example>xrmBrowser.Entity.ClearValue(new CompositeControl() {Id = "fullname"});</example>
+        public BrowserCommandResult<bool> ClearValue(CompositeControl control)
+        {
+            return this.Execute(GetOptions($"Clear Conposite Control Value: {control.Id}"), driver =>
+            {
+                /*
+                driver.WaitUntilVisible(By.Id(control.Id));
+
+                if (!driver.HasElement(By.Id(control.Id)))
+                    return false;
+
+                driver.ClickWhenAvailable(By.Id(control.Id));
+
+                if (driver.HasElement(By.Id(control.Id + Elements.ElementId[Reference.SetValue.FlyOut])))
+                {
+                    var compcntrl =
+                        driver.FindElement(By.Id(control.Id + Elements.ElementId[Reference.SetValue.FlyOut]));
+
+                    foreach (var field in control.Fields)
+                    {
+                        compcntrl.FindElement(By.Id(control.Id + Elements.ElementId[Reference.SetValue.CompositionLinkControl] + field.Id)).Click();
+
+                        var result = compcntrl.FindElements(By.TagName("input"))
+                            .ToList()
+                            .FirstOrDefault(i => i.GetAttribute("id").Contains(field.Id));
+
+                        //BugFix - Setvalue -The value is getting erased even after setting the value ,might be due to recent CSS changes.
+                        driver.ExecuteScript("document.getElementById('" + result?.GetAttribute("id") + "').value = ''");
+                        result?.SendKeys(field.Value);
+                    }
+
+                    compcntrl.FindElement(By.Id(control.Id + Elements.ElementId[Reference.SetValue.Confirm])).Click();
+                }
+                else
+                    throw new InvalidOperationException($"Composite Control: {control.Id} Does not exist");
+
+                */
+                return true;
+            });
+        }
+
+        /// <summary>
+        /// Placeholder: Clears the value of a Field.
+        /// </summary>
+        /// <param name="field">The field .</param>
+        public BrowserCommandResult<bool> ClearValue(Field field)
+        {
+            return this.Execute(GetOptions($"Clear Value: {field.Name}"), driver =>
+            {
+                /*
+                driver.WaitUntilVisible(By.Id(field.Id));
+
+                if (driver.HasElement(By.Id(field.Id)))
+                {
+                    var fieldElement = driver.ClickWhenAvailable(By.Id(field.Id));
+
+                    //Check to see if focus is on field already
+                    if (fieldElement.FindElement(By.ClassName(Elements.CssClass[Reference.SetValue.EditClass])) != null)
+                        fieldElement.FindElement(By.ClassName(Elements.CssClass[Reference.SetValue.EditClass])).Click();
+                    else
+                        fieldElement.FindElement(By.ClassName(Elements.CssClass[Reference.SetValue.ValueClass])).Click();
+
+
+                    if (fieldElement.FindElements(By.TagName("textarea")).Count > 0)
+                    {
+                        fieldElement.FindElement(By.TagName("textarea")).Clear();
+                        fieldElement.FindElement(By.TagName("textarea")).SendKeys(field.Value);
+                    }
+                    else
+                    {
+                        fieldElement.FindElement(By.TagName("input")).Clear();
+                        fieldElement.FindElement(By.TagName("input")).SendKeys(field.Value);
+                    }
+
+                }
+                else
+                    throw new InvalidOperationException($"Field: {field} Does not exist");
+                */
+                return true;
             });
         }
 

--- a/Microsoft.Dynamics365.UIAutomation.Sample/Web/BusinessProcessFlow/BusinessProcessFlow.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Sample/Web/BusinessProcessFlow/BusinessProcessFlow.cs
@@ -238,11 +238,11 @@ namespace Microsoft.Dynamics365.UIAutomation.Sample.Web
                 xrmBrowser.ThinkTime(2000);
 
                 // Set Value on a TwoOption field in a Business Process Flow
-                xrmBrowser.BusinessProcessFlow.SetValue("identifycustomercontacts", true);
+                xrmBrowser.BusinessProcessFlow.SetValue(new TwoOption { Name = "identifycustomercontacts" });
 
                 xrmBrowser.ThinkTime(1000);
 
-                var checkBoxValue = xrmBrowser.BusinessProcessFlow.GetValue("identifycustomercontacts", true);
+                var checkBoxValue = xrmBrowser.BusinessProcessFlow.GetValue(new TwoOption { Name = "identifycustomercontacts" });
 
                 xrmBrowser.BusinessProcessFlow.NextStage();
 
@@ -252,7 +252,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Sample.Web
 
                 xrmBrowser.ThinkTime(2000);
 
-                xrmBrowser.BusinessProcessFlow.SetValue("finaldecisiondate", DateTime.Parse("01/15/2019"));
+                xrmBrowser.BusinessProcessFlow.SetValue(new DateTimeControl { Name = "finaldecisiondate", Value = DateTime.Parse("01/15/2019") });
 
                 xrmBrowser.BusinessProcessFlow.Finish();
 
@@ -262,6 +262,138 @@ namespace Microsoft.Dynamics365.UIAutomation.Sample.Web
             }
         }
 
+        [TestMethod]
+        public void WEBTestLeadToOpportunityBPFClearAndSetValue()
+        {
+            using (var xrmBrowser = new Api.Browser(TestSettings.Options))
+            {
+                xrmBrowser.LoginPage.Login(_xrmUri, _username, _password);
 
+                //xrmBrowser.GuidedHelp.CloseGuidedHelp(5000);
+
+                xrmBrowser.Navigation.OpenSubArea("Sales", "Leads");
+
+                xrmBrowser.Grid.SwitchView("Open Leads");
+
+                xrmBrowser.CommandBar.ClickCommand("New");
+
+                List<Field> fields = new List<Field>
+                {
+                    new Field() {Id = "firstname", Value = "Test"},
+                    new Field() {Id = "lastname", Value = "Lead"}
+                };
+
+                xrmBrowser.ThinkTime(2000);
+
+                xrmBrowser.Entity.SetValue("subject", "Test API Lead BPF");
+                xrmBrowser.Entity.SetValue(new CompositeControl() { Id = "fullname", Fields = fields });
+                xrmBrowser.Entity.SetValue("mobilephone", "555-555-5555");
+                xrmBrowser.Entity.SetValue("description", "Test lead creation with API commands");               
+
+                xrmBrowser.ThinkTime(2000);
+
+                xrmBrowser.BusinessProcessFlow.SetValue(new LookupItem { Name = "parentaccountid", Value = "Adventure Works (sample)" });
+
+                xrmBrowser.ThinkTime(2000);
+
+                var lookupValue = xrmBrowser.BusinessProcessFlow.GetValue(new LookupItem { Name = "parentaccountid" }).Value;
+
+                Assert.IsNotNull(lookupValue);
+
+                xrmBrowser.BusinessProcessFlow.ClearValue(new LookupItem { Name = "parentaccountid" });
+
+                lookupValue = xrmBrowser.BusinessProcessFlow.GetValue(new LookupItem { Name = "parentaccountid" }).Value;
+
+                Assert.AreEqual("click to enter", lookupValue.ToLower());
+
+                // Set Value of a Textbox field in a Business Process Flow
+                xrmBrowser.BusinessProcessFlow.SetValue("Description", "Test description value in BPF");
+
+                xrmBrowser.ThinkTime(2000);
+
+                var textValue = xrmBrowser.BusinessProcessFlow.GetValue("description").Value;
+
+                Assert.IsNotNull(textValue);
+
+                xrmBrowser.BusinessProcessFlow.ClearValue("description");
+
+                textValue = xrmBrowser.BusinessProcessFlow.GetValue("description").Value;
+                
+                Assert.AreEqual("", textValue);
+
+                xrmBrowser.BusinessProcessFlow.SetValue(new OptionSet { Name = "purchaseprocess", Value = "Committee" });
+
+                xrmBrowser.ThinkTime(2000);
+
+                var optionValue = xrmBrowser.BusinessProcessFlow.GetValue(new OptionSet { Name = "purchaseprocess" }).Value;
+
+                Assert.IsNotNull(optionValue);
+
+                xrmBrowser.BusinessProcessFlow.ClearValue(new OptionSet { Name = "purchaseprocess" });
+
+                optionValue = xrmBrowser.BusinessProcessFlow.GetValue(new OptionSet { Name = "purchaseprocess" }).Value;
+
+                Assert.AreEqual("click to enter", optionValue.ToLower());
+
+                xrmBrowser.CommandBar.ClickCommand("Save");
+
+                xrmBrowser.ThinkTime(2000);
+
+                xrmBrowser.CommandBar.ClickCommand("Qualify");
+
+                xrmBrowser.Dialogs.QualifyLead(true, 4000);
+
+                xrmBrowser.ThinkTime(10000);
+
+                xrmBrowser.BusinessProcessFlow.PreviousStage();
+
+                xrmBrowser.ThinkTime(2000);
+
+                xrmBrowser.BusinessProcessFlow.NextStage(0, 2000);
+
+                xrmBrowser.ThinkTime(2000);
+
+                // Set Value on a TwoOption field in a Business Process Flow
+                xrmBrowser.BusinessProcessFlow.SetValue(new TwoOption { Name = "identifycustomercontacts", Value = "Completed"});
+
+                xrmBrowser.ThinkTime(1000);
+
+                var checkBoxValue = xrmBrowser.BusinessProcessFlow.GetValue(new TwoOption { Name = "identifycustomercontacts" }).Value;
+
+                Assert.IsTrue(checkBoxValue);
+
+                xrmBrowser.BusinessProcessFlow.ClearValue(new TwoOption { Name = "identifycustomercontacts" });
+
+                checkBoxValue = xrmBrowser.BusinessProcessFlow.GetValue(new TwoOption { Name = "identifycustomercontacts" }).Value;
+
+                Assert.IsFalse(checkBoxValue);
+
+                xrmBrowser.BusinessProcessFlow.NextStage();
+
+                xrmBrowser.ThinkTime(2000);
+
+                xrmBrowser.BusinessProcessFlow.NextStage();
+
+                xrmBrowser.ThinkTime(2000);
+
+                xrmBrowser.BusinessProcessFlow.SetValue(new DateTimeControl { Name = "finaldecisiondate", Value = DateTime.Parse("01/15/2019") });
+
+                var dateTimeValue = xrmBrowser.BusinessProcessFlow.GetValue(new DateTimeControl { Name = "finaldecisiondate" }).Value;
+
+                Assert.IsNotNull(dateTimeValue);
+
+                xrmBrowser.BusinessProcessFlow.ClearValue(new DateTimeControl { Name = "finaldecisiondate"});
+
+                dateTimeValue = xrmBrowser.BusinessProcessFlow.GetValue(new DateTimeControl { Name = "finaldecisiondate" }).Value;
+
+                Assert.AreEqual("--",dateTimeValue);
+
+                xrmBrowser.BusinessProcessFlow.Finish();
+
+                xrmBrowser.BusinessProcessFlow.Hide();
+
+                xrmBrowser.ThinkTime(3000);
+            }
+        }
     }
 }

--- a/Microsoft.Dynamics365.UIAutomation.Sample/Web/Entity/Entity.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Sample/Web/Entity/Entity.cs
@@ -5,6 +5,10 @@ namespace Microsoft.Dynamics365.UIAutomation.Sample.Web
 {
     using Microsoft.Dynamics365.UIAutomation.Api;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
 
     [TestClass]
     public class Entity : TestBase
@@ -37,6 +41,31 @@ namespace Microsoft.Dynamics365.UIAutomation.Sample.Web
         {
             XrmTestBrowser.Grid.OpenRecord(0);
             var recordGuid = XrmTestBrowser.Entity.GetRecordGuid().Value;
+            XrmTestBrowser.ThinkTime(5000);
+        }
+
+        [TestMethod]
+        public void WEBTestSetGetClearCompositeValues()
+        {
+            XrmTestBrowser.CommandBar.ClickCommand("New");
+
+            List<Field> fields = new List<Field>
+                {
+                    new Field() {Id = "firstname", Value = "EasyRepro"},
+                    new Field() {Id = "lastname", Value = "Entity Test"}
+                };
+
+            XrmTestBrowser.Entity.SetValue(new CompositeControl { Id = "fullname", Fields = fields}); //Composite Field
+            var fullNameValue = XrmTestBrowser.Entity.GetValue(new CompositeControl { Id = "fullname", Fields = fields }).Value; //Composite Field
+            var fullNameTest = string.Join(" ", fields.Select(x => x.Value).ToArray());
+            Assert.IsTrue(fullNameValue.Equals(fullNameTest));
+            
+            // The code below is an example of using ClearValue on a CompositeControl 
+            // In this example, one of the fields is required and as a result we cannot clear the composite field.
+            // Throw exception on the test to alert this issue
+
+            // XrmTestBrowser.Entity.ClearValue(new CompositeControl { Id = "fullname", Fields = fields }); //Composite Required Field Example --> EXCEPTION
+
             XrmTestBrowser.ThinkTime(5000);
         }
 

--- a/Microsoft.Dynamics365.UIAutomation.Sample/Web/Entity/Entity.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Sample/Web/Entity/Entity.cs
@@ -3,6 +3,7 @@
 
 namespace Microsoft.Dynamics365.UIAutomation.Sample.Web
 {
+    using Microsoft.Dynamics365.UIAutomation.Api;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
     [TestClass]
@@ -40,12 +41,35 @@ namespace Microsoft.Dynamics365.UIAutomation.Sample.Web
         }
 
         [TestMethod]
-        public void WEBTestClearRecordValues()
+        public void WEBTestSetGetClearRecordValues()
         {
-            XrmTestBrowser.Grid.OpenRecord(0);
+            OpenEntity("Sales", "Quotes", "All Quotes");
+            XrmTestBrowser.CommandBar.ClickCommand("New");
 
-            //XrmTestBrowser.Entity.SetValue("") //Text Field
-            //XrmTestBrowser.Entity.ClearValue(""); //Text field
+            XrmTestBrowser.Entity.SetValue("name", "EasyRepro Quote"); //Text Field
+            var quoteName = XrmTestBrowser.Entity.GetValue("name").Value; //Text field
+            Assert.IsNotNull(quoteName);
+            XrmTestBrowser.Entity.ClearValue("name"); //Text field
+
+            XrmTestBrowser.Entity.SetValue(new LookupItem {Name = "opportunityid", Index = 0 }); //Lookup Field
+            var opportunityLookup = XrmTestBrowser.Entity.GetValue(new LookupItem { Name = "opportunityid" }).Value; //Lookup Field
+            Assert.IsNotNull(opportunityLookup);
+            XrmTestBrowser.Entity.ClearValue(new LookupItem { Name = "opportunityid" }); //Lookup Field
+
+            XrmTestBrowser.Entity.SetValue(new DateTimeControl { Name = "effectiveto", Value = System.DateTime.Parse("06/15/2019") }); //DateTime Field
+            var quoteExpiration = XrmTestBrowser.Entity.GetValue(new DateTimeControl { Name = "effectiveto", Value = System.DateTime.Parse("06/15/2019") }).Value; //DateTime Field
+            Assert.AreEqual(System.DateTime.Parse(quoteExpiration), System.DateTime.Parse("06/15/2019"));
+            XrmTestBrowser.Entity.ClearValue(new DateTimeControl { Name = "effectiveto" }); //DateTime Field
+
+            XrmTestBrowser.Entity.SetValue(new OptionSet { Name = "shippingmethodcode", Value = "Postal Mail" }); //OptionSet field
+            var optionSetValue = XrmTestBrowser.Entity.GetValue(new OptionSet { Name = "shippingmethodcode" }).Value; //OptionSet field
+            Assert.IsNotNull(optionSetValue);
+            XrmTestBrowser.Entity.ClearValue(new OptionSet { Name = "shippingmethodcode" }); //OptionSet field
+
+            XrmTestBrowser.Entity.SetValue(new TwoOption { Name = "willcall", Value = "Will Call" }); //TwoOption field
+            var twoOptionValue = XrmTestBrowser.Entity.GetValue(new TwoOption { Name = "willcall" }).Value; //TwoOption field --> 0 (Address) = False, 1 (WillCall) = True. 
+            Assert.IsTrue(twoOptionValue);
+            XrmTestBrowser.Entity.ClearValue(new TwoOption { Name = "willcall" }); //TwoOption field
 
             XrmTestBrowser.ThinkTime(5000);
         }

--- a/Microsoft.Dynamics365.UIAutomation.Sample/Web/Entity/Entity.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Sample/Web/Entity/Entity.cs
@@ -38,5 +38,16 @@ namespace Microsoft.Dynamics365.UIAutomation.Sample.Web
             var recordGuid = XrmTestBrowser.Entity.GetRecordGuid().Value;
             XrmTestBrowser.ThinkTime(5000);
         }
+
+        [TestMethod]
+        public void WEBTestClearRecordValues()
+        {
+            XrmTestBrowser.Grid.OpenRecord(0);
+
+            //XrmTestBrowser.Entity.SetValue("") //Text Field
+            //XrmTestBrowser.Entity.ClearValue(""); //Text field
+
+            XrmTestBrowser.ThinkTime(5000);
+        }
     }
 }


### PR DESCRIPTION
Introducing ClearValue methods for BPF and Entity 
Introducing GetValue methods for BPF and Entity
Updates to SetValue methods for bPF and Entity
Introduced two new control types: TwoOption and DateTimeControl
Deprecated legacy Checkbox/TwoOption and DateTime methods.