### PR TITLE
Adding element wait check for timeline consistency

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -2421,6 +2421,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 driver.ClickWhenAvailable(menuName);
                 try
                 {
+                    driver.WaitUntilAvailable(menuItemName);
                     driver.ClickWhenAvailable(menuItemName);
                 }
                 catch


### PR DESCRIPTION
Adding WaitUntilAvailable to ensure the Timeline popout menu is bothopened and clicked, allowing SetValue to work as expected.