### PR TITLE
Allows browser height & width to be set manually

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Browser/BrowserDriverFactory.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Browser/BrowserDriverFactory.cs
@@ -49,8 +49,11 @@ namespace Microsoft.Dynamics365.UIAutomation.Browser
 
             driver.Manage().Timeouts().PageLoad = options.PageLoadTimeout;
 
-            if(options.StartMaximized && options.BrowserType != BrowserType.Chrome) //Handle Chrome in the Browser Options
+            // StartMaximized overrides a set width & height
+            if (options.StartMaximized && options.BrowserType != BrowserType.Chrome) //Handle Chrome in the Browser Options
                 driver.Manage().Window.Maximize();
+            else if (!options.StartMaximized && options.Width.HasValue && options.Height.HasValue)
+                driver.Manage().Window.Size = new System.Drawing.Size(options.Width.Value, options.Height.Value);
 
             if (options.FireEvents || options.EnableRecording)
             {

--- a/Microsoft.Dynamics365.UIAutomation.Browser/BrowserOptions.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Browser/BrowserOptions.cs
@@ -27,6 +27,8 @@ namespace Microsoft.Dynamics365.UIAutomation.Browser
             this.RecordingScanInterval = TimeSpan.FromMilliseconds(Constants.Browser.Recording.DefaultScanInterval);
             this.Credentials = BrowserCredentials.Default;
             this.HideDiagnosticWindow = true;
+            this.Height = null;
+            this.Width = null;
         }
 
         public BrowserType BrowserType { get; set; }
@@ -36,6 +38,9 @@ namespace Microsoft.Dynamics365.UIAutomation.Browser
         public bool CleanSession { get; set; }
         public TimeSpan PageLoadTimeout { get; set; }
         public TimeSpan CommandTimeout { get; set; }
+        /// <summary>
+        /// When <see langword="true" /> the browser will open maximized at the highest supported resolution.
+        /// </summary>
         public bool StartMaximized { get; set; }
         public bool FireEvents { get; set; }
         public bool EnableRecording { get; set; }
@@ -46,6 +51,14 @@ namespace Microsoft.Dynamics365.UIAutomation.Browser
         public bool UserAgent { get; set; }
         public string UserAgentValue { get; set; }
         public int DefaultThinkTime { get; set; }
+        /// <summary>
+        /// Gets or sets the browser height when <see cref="StartMaximized"/> is <see langword="false" />. Both <see cref="Height"/> and <see cref="Width"/> must be set.
+        /// </summary>
+        public int? Height { get; set; }
+        /// <summary>
+        /// Gets or sets the browser width when Both <see cref="StartMaximized"/> is <see langword="false" />. Both <see cref="Height"/> and <see cref="Width"/> must be set.
+        /// </summary>
+        public int? Width { get; set; }
 
         public virtual ChromeOptions ToChrome()
         {


### PR DESCRIPTION
Allows browser height & width to be set manually to a larger size than the current resolution supports. Example: Azure DevOps hosted agent supports 1024 x 768 but that often causes UCI tests to fail because elements are not visible. Manually setting to 1920 x 1080 resolves. 