### PR TITLE
Make XrmBrowser SetValue for lookup use new value to search before to picking dialog result

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api/DTOs/ElementReference.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api/DTOs/ElementReference.cs
@@ -141,6 +141,8 @@ namespace Microsoft.Dynamics365.UIAutomation.Api
             { "Entity_CheckboxFieldContainer"     , "//div[@id=\"[NAME]\"]" },
             { "Entity_OptionSetFieldContainer"     , "//div[@id=\"[NAME]\"]" },
             { "Entity_LookupFieldContainer"     , "//div[@id=\"[NAME]\"]" },
+            { "Entity_LookupFieldTd"     , "//td[@id=\"[NAME]_d\"]" },
+            { "Entity_LookupFieldInput"     , "//input[@id=\"[NAME]_ledit\"]" },
             { "Entity_DateFieldContainer"     , "//div[@id=\"[NAME]\"]" },
             { "Entity_DateFieldInput"     , "//input[@id=\"[NAME]_iDateInput\"]" },
             { "Entity_GetLookupSearchIcon"     , "//div[@id=\"[NAME]_lookupSearchIconDiv\"]" },
@@ -643,6 +645,8 @@ namespace Microsoft.Dynamics365.UIAutomation.Api
             public static string CheckboxFieldContainer = "Entity_CheckboxFieldContainer";
             public static string OptionSetFieldContainer = "Entity_OptionSetFieldContainer";
             public static string LookupFieldContainer = "Entity_LookupFieldContainer";
+            public static string LookupFieldTd= "Entity_LookupFieldTd";
+            public static string LookupFieldInput= "Entity_LookupFieldInput";
             public static string DateFieldContainer = "Entity_DateFieldContainer";
             public static string DateFieldInput = "Entity_DateFieldInput";
             public static string GetLookupSearchIcon = "Entity_GetLookupSearchIcon";

--- a/Microsoft.Dynamics365.UIAutomation.Api/XrmPage.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api/XrmPage.cs
@@ -559,6 +559,9 @@ namespace Microsoft.Dynamics365.UIAutomation.Api
                         return true;
                     }
 
+                    if (!openLookupPage)
+                        return true;
+
                     var input = driver.ClickWhenAvailable(By.Id(field.Name));
 
                     if (input.FindElement(By.ClassName(Elements.CssClass[Reference.SetValue.LookupRenderClass])) == null)
@@ -991,12 +994,19 @@ namespace Microsoft.Dynamics365.UIAutomation.Api
             {
                 if (driver.HasElement(By.Id(control.Name)))
                 {
+                    if (control.Value != null)
+                        SelectLookup(control, true, false);
+
                     driver.WaitUntilVisible(By.Id(control.Name));
 
                     var input = driver.ClickWhenAvailable(By.Id(control.Name));
 
                     if (input.FindElement(By.ClassName(Elements.CssClass[Reference.SetValue.LookupRenderClass])) == null)
                         throw new InvalidOperationException($"Field: {control.Name} is not lookup");
+
+                    driver.ClickWhenAvailable(By.XPath(Elements.Xpath[Reference.Entity.LookupFieldTd].Replace("[NAME]", control.Name)));
+                    var editInput = driver.FindElement(By.XPath(Elements.Xpath[Reference.Entity.LookupFieldInput].Replace("[NAME]", control.Name)));
+                    editInput.SendKeys(control.Value);
 
                     input.FindElement(By.ClassName(Elements.CssClass[Reference.SetValue.LookupRenderClass])).Click();
 


### PR DESCRIPTION
Updated SetValue for lookup to use the parameter value to match in the dialog versus only looking at the immediate results.

Updated SelectLookup function to utilize previously unused parameter to prevent lookup dialog from opening after clearing the field.