### PR TITLE
Added support for remote execution (#475)

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Browser/BrowserDriverFactory.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Browser/BrowserDriverFactory.cs
@@ -8,6 +8,7 @@ using OpenQA.Selenium.IE;
 using OpenQA.Selenium.PhantomJS;
 using OpenQA.Selenium.Support.Events;
 using OpenQA.Selenium.Edge;
+using OpenQA.Selenium.Remote;
 using System;
 
 namespace Microsoft.Dynamics365.UIAutomation.Browser
@@ -40,7 +41,19 @@ namespace Microsoft.Dynamics365.UIAutomation.Browser
                     var edgeService = EdgeDriverService.CreateDefaultService();
                     edgeService.HideCommandPromptWindow = options.HideDiagnosticWindow;
                     driver = new EdgeDriver(edgeService,options.ToEdge(), TimeSpan.FromMinutes(20));
-
+                    break;
+                case BrowserType.Remote:
+                    ICapabilities capabilities = null;
+                    switch (options.RemoteBrowserType)
+                    {
+                        case BrowserType.Chrome:
+                            capabilities = options.ToChrome().ToCapabilities();
+                            break;
+                        case BrowserType.Firefox:
+                            capabilities = options.ToFireFox().ToCapabilities();
+                            break;
+                    }
+                    driver = new RemoteWebDriver(options.RemoteHubServer, capabilities, TimeSpan.FromMinutes(20));
                     break;
                 default:
                     throw new InvalidOperationException(

--- a/Microsoft.Dynamics365.UIAutomation.Browser/BrowserOptions.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Browser/BrowserOptions.cs
@@ -29,6 +29,8 @@ namespace Microsoft.Dynamics365.UIAutomation.Browser
             this.HideDiagnosticWindow = true;
         }
 
+        public BrowserType RemoteBrowserType { get; set; }
+        public Uri RemoteHubServer { get; set; }
         public BrowserType BrowserType { get; set; }
         public BrowserCredentials Credentials { get; set; }
         public string DriversPath { get; set; }

--- a/Microsoft.Dynamics365.UIAutomation.Sample/TestSettings.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Sample/TestSettings.cs
@@ -12,6 +12,8 @@ namespace Microsoft.Dynamics365.UIAutomation.Sample
         public static string LookupField = "primarycontactid";
         public static string LookupName = "Rene Valdes (sample)";
         private static readonly string Type = System.Configuration.ConfigurationManager.AppSettings["BrowserType"].ToString();
+        private static readonly string RemoteType = System.Configuration.ConfigurationManager.AppSettings["RemoteBrowserType"].ToString();
+        private static readonly string RemoteHubServerURL = System.Configuration.ConfigurationManager.AppSettings["RemoteHubServer"].ToString();
 
         public static BrowserOptions Options = new BrowserOptions
         {
@@ -20,7 +22,9 @@ namespace Microsoft.Dynamics365.UIAutomation.Sample
             FireEvents = false,
             Headless = false,
             UserAgent = false,
-            DefaultThinkTime = 2000
+            DefaultThinkTime = 2000,
+            RemoteBrowserType = (BrowserType)Enum.Parse(typeof(BrowserType), RemoteType),
+            RemoteHubServer = new Uri(RemoteHubServerURL)
         };
 
         public static string GetRandomString(int minLen, int maxLen)

--- a/Microsoft.Dynamics365.UIAutomation.Sample/app.config
+++ b/Microsoft.Dynamics365.UIAutomation.Sample/app.config
@@ -15,8 +15,11 @@
     <add key="OnlinePassword" value="" />
     <add key="OnlineCrmUrl" value="" />
     <add key="AzureKey" value="" />
-    <!-- IE,Chrome,Firefox,Edge-->
+    <!-- IE,Chrome,Firefox,Edge,Remote-->
     <add key="BrowserType" value="Chrome"/>
+    <!-- The following settings are only used if BrowserType = "Remote" above -->
+    <add key="RemoteBrowserType" value="Chrome"/>
+    <add key="RemoteHubServer" value="http://1.1.1.1:4444/wd/hub"/>
   </appSettings>
   <system.web>
     <membership defaultProvider="ClientAuthenticationMembershipProvider">


### PR DESCRIPTION
Added remote execution support for selenium grid for Firefox and Chrome web browsers. This is useful when you need to perform a large number of tests.