### PR TITLE
Updated UCI optionset gets/sets to handle statuscode field

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/AppElementReference.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/AppElementReference.cs
@@ -117,6 +117,10 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             public static string EntityBooleanFieldCheckboxContainer = "Entity_BooleanFieldCheckboxContainer";
             public static string EntityBooleanFieldCheckbox = "Entity_BooleanFieldCheckbox";
             public static string EntityBooleanFieldList = "Entity_BooleanFieldList";
+            public static string EntityOptionsetStatusCombo = "Entity_OptionsetStatusCombo";
+            public static string EntityOptionsetStatusComboButton = "Entity_OptionsetStatusComboButton";
+            public static string EntityOptionsetStatusComboList = "Entity_OptionsetStatusComboList";
+            public static string EntityOptionsetStatusTextValue = "Entity_OptionsetStatusTextValue";
 
         }
 
@@ -334,6 +338,10 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             { "Entity_BooleanFieldCheckboxContainer", "//div[contains(@data-id, '[NAME].fieldControl-checkbox-container')]"},
             { "Entity_BooleanFieldCheckbox", "//input[contains(@data-id, '[NAME].fieldControl-checkbox-toggle')]"},
             { "Entity_BooleanFieldList", "//select[contains(@data-id, '[NAME].fieldControl-checkbox-select')]"},
+            { "Entity_OptionsetStatusCombo", "//div[contains(@data-id, '[NAME].fieldControl-pickliststatus-comboBox')]"},
+            { "Entity_OptionsetStatusComboButton", "//div[contains(@id, '[NAME].fieldControl-pickliststatus-comboBox_button')]"},
+            { "Entity_OptionsetStatusComboList", "//ul[contains(@id, '[NAME].fieldControl-pickliststatus-comboBox_list')]"},
+            { "Entity_OptionsetStatusTextValue", "//span[contains(@id, '[NAME].fieldControl-pickliststatus-comboBox_text-value')]"},
 			
                         
             //CommandBar

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/Elements/Entity.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/Elements/Entity.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         }
 
         /// <summary>
-        /// Gets the value of an OptionSet from the header
+        /// Gets the value of a picklist or status field from the header
         /// </summary>
         /// <param name="option">The option you want to Get.</param>
         /// <example>xrmBrowser.Entity.GetValue(new OptionSet { Name = "preferredcontactmethodcode"}); </example>
@@ -187,7 +187,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         }
 
         /// <summary>
-        /// Gets the value of a OptionSet.
+        /// Gets the value of a picklist or status field.
         /// </summary>
         /// <param name="option">The option you want to set.</param>
         public string GetValue(OptionSet optionSet)
@@ -294,7 +294,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         }
 
         /// <summary>
-        /// Sets the value of an OptionSet in the header
+        /// Sets the value of a picklist or status field in the header
         /// </summary>
         /// <param name="option">The option you want to set.</param>
         public void SetHeaderValue(OptionSet control)
@@ -331,7 +331,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         }
 
         /// <summary>
-        /// Sets the value of a picklist.
+        /// Sets the value of a picklist or status field.
         /// </summary>
         /// <param name="option">The option you want to set.</param>
         public void SetValue(OptionSet optionSet)

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -1691,10 +1691,10 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         }
 
         /// <summary>
-        /// Sets the value of a picklist.
+        /// Sets the value of a picklist or status field.
         /// </summary>
         /// <param name="option">The option you want to set.</param>
-        /// <example>xrmBrowser.Entity.SetValue(new OptionSet { Name = "preferredcontactmethodcode", Value = "Email" });</example>
+        /// <example>xrmApp.Entity.SetValue(new OptionSet { Name = "preferredcontactmethodcode", Value = "Email" });</example>
         public BrowserCommandResult<bool> SetValue(OptionSet option)
         {
             return this.Execute(GetOptions($"Set OptionSet Value: {option.Name}"), driver =>
@@ -1705,6 +1705,21 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 {
                     var select = fieldContainer.FindElement(By.TagName("select"));
                     var options = select.FindElements(By.TagName("option"));
+
+                    foreach (var op in options)
+                    {
+                        if (op.Text != option.Value && op.GetAttribute("value") != option.Value) continue;
+                        op.Click();
+                        break;
+                    }
+                }
+                else if (fieldContainer.FindElements(By.XPath(AppElements.Xpath[AppReference.Entity.EntityOptionsetStatusCombo].Replace("[NAME]", option.Name))).Count > 0)
+                {
+                    // This is for statuscode (type = status) that should act like an optionset doesn't doesn't follow the same pattern when rendered
+                    driver.ClickWhenAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.EntityOptionsetStatusComboButton].Replace("[NAME]", option.Name)));
+                    
+                    var listBox = driver.FindElement(By.XPath(AppElements.Xpath[AppReference.Entity.EntityOptionsetStatusComboList].Replace("[NAME]", option.Name)));
+                    var options = listBox.FindElements(By.TagName("li"));
 
                     foreach (var op in options)
                     {
@@ -2020,10 +2035,10 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         }
 
         /// <summary>
-        /// Gets the value of a picklist.
+        /// Gets the value of a picklist or status field.
         /// </summary>
         /// <param name="option">The option you want to set.</param>
-        /// <example>xrmBrowser.Entity.GetValue(new OptionSet { Name = "preferredcontactmethodcode"}); </example>
+        /// <example>xrmApp.Entity.GetValue(new OptionSet { Name = "preferredcontactmethodcode"}); </example>
         internal BrowserCommandResult<string> GetValue(OptionSet option)
         {
             return this.Execute($"Get OptionSet Value: {option.Name}", driver =>
@@ -2041,6 +2056,13 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                         text = op.Text;
                         break;
                     }
+                }
+                else if (fieldContainer.FindElements(By.XPath(AppElements.Xpath[AppReference.Entity.EntityOptionsetStatusCombo].Replace("[NAME]", option.Name))).Count > 0)
+                {
+                    // This is for statuscode (type = status) that should act like an optionset doesn't doesn't follow the same pattern when rendered
+                    var valueSpan = driver.FindElement(By.XPath(AppElements.Xpath[AppReference.Entity.EntityOptionsetStatusTextValue].Replace("[NAME]", option.Name)));
+
+                    text = valueSpan.Text;
                 }
                 else
                 {


### PR DESCRIPTION
Issue #468 Updated UCI optionset gets/sets to handle statuscode field which does not render as a select. Didn't create a new set of methods for this to follow the same cadence as the SDK where is handles like a standard optionset.