### PR TITLE
UCI added new navigation method to open a subarea based on the group

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/AppElementReference.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/AppElementReference.cs
@@ -36,6 +36,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             public static string QuickCreateMenuList = "Nav_QuickCreateMenuList";
             public static string QuickCreateMenuItems = "Nav_QuickCreateMenuItems";
             public static string PinnedSitemapEntity = "Nav_PinnedSitemapEntity";
+            public static string SitemapMenuGroup = "Nav_SitemapMenuGroup";
             public static string SitemapMenuItems = "Nav_SitemapMenuItems";
             public static string SitemapSwitcherButton = "Nav_SitemapSwitcherButton";
             public static string SitemapSwitcherFlyout = "Nav_SitemapSwitcherFlyout";
@@ -247,6 +248,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             { "Nav_QuickCreateMenuList", "//ul[contains(@id,'MenuSectionItemsquickCreate')]" },
             { "Nav_QuickCreateMenuItems", "//li[@role='menuitem']" },
             { "Nav_PinnedSitemapEntity","//li[contains(@data-id,'sitemap-entity-Pinned') and contains(@role,'treeitem')]"},
+            { "Nav_SitemapMenuGroup", "//ul[@role=\"group\"]"},
             { "Nav_SitemapMenuItems", "//li[contains(@data-id,'sitemap-entity')]"},
             { "Nav_SitemapSwitcherButton", "//button[contains(@data-id,'sitemap-areaSwitcher-expand-btn')]"},
             { "Nav_SitemapSwitcherFlyout","//div[contains(@data-lp-id,'sitemap-area-switcher-flyout')]"},

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/Elements/Navigation.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/Elements/Navigation.cs
@@ -25,6 +25,8 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 
         /// <summary>
         /// Opens a sub area from a group in the active app &amp; area
+        /// This can be used to navigate within the active app/area or when the app only has a single area
+        /// It will not navigate to a different app or area within the app
         /// </summary>
         /// <param name="group">Name of the group</param>
         /// <param name="subarea">Name of the subarea</param>

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/Elements/Navigation.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/Elements/Navigation.cs
@@ -24,6 +24,17 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         }
 
         /// <summary>
+        /// Opens a sub area from a group in the active app &amp; area
+        /// </summary>
+        /// <param name="group">Name of the group</param>
+        /// <param name="subarea">Name of the subarea</param>
+        /// <example>xrmApp.Navigation.OpenGroupSubArea("Customers", "Accounts");</example>
+        public void OpenGroupSubArea(string group, string subarea)
+        {
+            _client.OpenGroupSubArea(group, subarea);
+        }
+
+        /// <summary>
         /// Opens a sub area in the unified client
         /// </summary>
         /// <param name="area">Name of the area</param>

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -216,6 +216,46 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             });
         }
 
+        internal BrowserCommandResult<bool> OpenGroupSubArea(string group, string subarea, int thinkTime = Constants.DefaultThinkTime)
+        {
+            this.Browser.ThinkTime(thinkTime);
+
+            return this.Execute(GetOptions("Open Group Sub Area"), driver =>
+            {
+                //Make sure the sitemap-launcher is expanded - 9.1
+                if (driver.HasElement(By.XPath(AppElements.Xpath[AppReference.Navigation.SiteMapLauncherButton])))
+                {
+                    var expanded = bool.Parse(driver.FindElement(By.XPath(AppElements.Xpath[AppReference.Navigation.SiteMapLauncherButton])).GetAttribute("aria-expanded"));
+
+                    if (!expanded)
+                        driver.ClickWhenAvailable(By.XPath(AppElements.Xpath[AppReference.Navigation.SiteMapLauncherButton]));
+                }
+
+                var groups = driver.FindElements(By.XPath(AppElements.Xpath[AppReference.Navigation.SitemapMenuGroup]));
+                var groupList = groups.FirstOrDefault(g => g.GetAttribute("aria-label").ToLowerString() == group.ToLowerString());
+                if (groupList == null)
+                {
+                    throw new NotFoundException($"No group with the name '{group}' exists");
+                }
+   
+                var subAreaItems = groupList.FindElements(By.XPath(AppElements.Xpath[AppReference.Navigation.SitemapMenuItems]));
+                var subAreaItem = subAreaItems.FirstOrDefault(a => a.GetAttribute("data-text").ToLowerString() == subarea.ToLowerString());
+                if (subAreaItem == null)
+                {
+                    throw new NotFoundException($"No subarea with the name '{subarea}' exists inside of '{group}'");
+                }
+
+                subAreaItem.Click(true);
+
+                driver.WaitUntilVisible(By.XPath(AppElements.Xpath[AppReference.Grid.Container]));
+                driver.WaitForPageToLoad();
+
+                driver.WaitForTransaction();
+
+                return true;
+            });
+        }
+
         internal BrowserCommandResult<bool> OpenSubArea(string area, string subarea, int thinkTime = Constants.DefaultThinkTime)
         {
             this.Browser.ThinkTime(thinkTime);

--- a/Microsoft.Dynamics365.UIAutomation.Sample/UCI/Navigation/OpenNavigation.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Sample/UCI/Navigation/OpenNavigation.cs
@@ -95,5 +95,23 @@ namespace Microsoft.Dynamics365.UIAutomation.Sample.UCI
                 xrmApp.Navigation.OpenMenu(Reference.MenuRelated.Related, Reference.MenuRelated.CommonActivities);
             }
         }
+
+        [TestMethod]
+        public void UCITestOpenGroupSubArea()
+        {
+            var client = new WebClient(TestSettings.Options);
+            using (var xrmApp = new XrmApp(client))
+            {
+                xrmApp.OnlineLogin.Login(_xrmUri, _username, _password);
+
+                xrmApp.Navigation.OpenApp(UCIAppName.Sales);
+
+                xrmApp.Navigation.OpenGroupSubArea("Customers", "Accounts");
+
+                xrmApp.Grid.OpenRecord(0);
+
+                xrmApp.ThinkTime(3000);
+            }
+        }
     }
 }


### PR DESCRIPTION
UCI added new navigation method to open a subarea based on the group name within the active app/area. Can be used to prevent reopening the the area if just changing subareas and also can be used to work around the issue when there is only a single area which isn't found (first open app and then group/subarea)  #398 amd #422