### PR TITLE
Replace WEBTestGetVersion with WEBTestRetrieveServerVersion

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api/DTOs/ElementReference.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api/DTOs/ElementReference.cs
@@ -84,6 +84,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api
             { "Nav_AppsForCrm"       , "id(\"navTabButtonSettingsNavAppsForCrmId\")"},
             { "Nav_WelcomeScreen"       , "id(\"navTabButtonSettingsNavTourId\")"},
             { "Nav_About"       , "id(\"navTabButtonSettingsAboutId\")"},
+            { "Nav_AboutVersionText"       , "//span[contains(text(), 'Version')]"},
             { "Nav_OptOutLP"       , "id(\"navTabButtonSettingsGuidedHelpId\")"},
             { "Nav_Privacy"       , "id(\"NodeSettingsPrivacyStatementId\")"},
             { "Nav_UserInfo"       , "id(\"navTabButtonUserInfoLinkId\")"},
@@ -591,6 +592,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api
             public static string AppsForCRM = "Nav_AppsForCrm";
             public static string WelcomeScreen = "Nav_WelcomeScreen";
             public static string About = "Nav_About";
+            public static string AboutVersionText = "Nav_AboutVersionText";
             public static string OptOutLP = "Nav_OptOutLP";
             public static string Privacy = "Nav_Privacy";
             public static string UserInfo = "Nav_UserInfo";

--- a/Microsoft.Dynamics365.UIAutomation.Api/Pages/Navigation.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api/Pages/Navigation.cs
@@ -451,6 +451,31 @@ namespace Microsoft.Dynamics365.UIAutomation.Api
         }
 
         /// <summary>
+        /// Opens About from navigation bar
+        /// </summary>
+        /// <param name="thinkTime">Used to simulate a wait time between human interactions. The Default is 2 seconds.</param>
+        /// <example>xrmBrowser.Navigation.RetrieveServerVersion();</example>
+        public BrowserCommandResult<string> RetrieveServerVersion(int thinkTime = Constants.DefaultThinkTime)
+        {
+            Browser.ThinkTime(thinkTime);
+
+            return this.Execute(GetOptions($"Open About"), driver =>
+            {
+                OpenSettingsOption(driver, Elements.Xpath[Reference.Navigation.About]);
+
+                driver.LastWindow().SwitchTo().ActiveElement();
+
+                var versionElement = driver.FindElement(By.XPath(Elements.Xpath[Reference.Navigation.AboutVersionText]));
+                var listedVersions = versionElement.FindElements(By.TagName("bdo"));
+
+                var serverVersion = listedVersions[1].Text.ToString().TrimStart('(').TrimEnd(')');
+
+                return serverVersion;
+            });
+        }
+
+
+        /// <summary>
         /// SignOut
         /// </summary>
         /// <param name="thinkTime">Used to simulate a wait time between human interactions. The Default is 2 seconds.</param>

--- a/Microsoft.Dynamics365.UIAutomation.Sample/Web/ValidationTests/ValidationVersion.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Sample/Web/ValidationTests/ValidationVersion.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Sample.Web
         private readonly Uri _xrmUri = new Uri(System.Configuration.ConfigurationManager.AppSettings["OnlineCrmUrl"].ToString());
 
         [TestMethod]
-        public void WEBTestGetVersion()
+        public void WEBTestRetrieveServerVersion()
         {
             using (var xrmBrowser = new Api.Browser(TestSettings.Options))
             {
@@ -25,14 +25,9 @@ namespace Microsoft.Dynamics365.UIAutomation.Sample.Web
 
                 xrmBrowser.ThinkTime(500);
 
-                xrmBrowser.Navigation.OpenAbout();
+                var serverVersion = xrmBrowser.Navigation.RetrieveServerVersion().Value;
 
-                xrmBrowser.Driver.LastWindow().SwitchTo().ActiveElement();
-
-                var dbVersion = xrmBrowser.Document.getElementByXPath("id(\"PageBody\")/table/tbody/tr[1]/td[2]/div/bdo[3]").Text;
-                var appVersion = xrmBrowser.Document.getElementByXPath("id(\"PageBody\")/table/tbody/tr[1]/td[2]/div/bdo[2]").Text.Replace("(","").Replace(")","");
-
-                Console.WriteLine("App Version: {0} , DB Version: {1}", appVersion, dbVersion);
+                Console.WriteLine($"Server Version for {_xrmUri} is: {serverVersion}");
             }
         }
     }


### PR DESCRIPTION
Introduced new method, Navigation.RetrieveServerVersion to return the server version for the desired org.