### PR TITLE
Adding UCITestMode option for full UI Testing

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/Elements/OnlineLogin.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/Elements/OnlineLogin.cs
@@ -24,6 +24,11 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         public void Login(Uri orgUrl, SecureString username, SecureString password)
         {
             _client.Login(orgUrl, username, password);
+
+            if (_client.Browser.Options.UCITestMode)
+            {
+                _client.InitializeTestMode();
+            }
         }
 
         /// <summary>
@@ -36,6 +41,11 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         public void Login(Uri orgUrl, SecureString username, SecureString password, Action<LoginRedirectEventArgs> redirectAction)
         {
             _client.Login(orgUrl, username, password, redirectAction);
+
+            if (_client.Browser.Options.UCITestMode)
+            {
+                _client.InitializeTestMode();
+            }
         }
 
     }

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 typeof(NoSuchElementException), typeof(StaleElementReferenceException));
         }
 
-        public BrowserCommandResult<bool> InitializeTestMode()
+        internal BrowserCommandResult<bool> InitializeTestMode()
         {
             return this.Execute(GetOptions("Initialize Unified Interface TestMode"), driver =>
             {

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -40,13 +40,13 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             return this.Execute(GetOptions("Initialize Unified Interface TestMode"), driver =>
             {
                 var uri = driver.Url;
+                var queryParams = "&flags=testmode=true";
 
-                if (!uri.Contains("flags=testmode=true"))
+                if (!uri.Contains(queryParams))
                 {
-                    var queryParams = "&flags=testmode=true";
-                    var newUri = uri + queryParams;
+                    var testModeUri = uri + queryParams;
 
-                    driver.Navigate().GoToUrl(newUri);
+                    driver.Navigate().GoToUrl(testModeUri);
 
                     driver.WaitForPageToLoad();
                     driver.WaitForTransaction();

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -35,6 +35,28 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 typeof(NoSuchElementException), typeof(StaleElementReferenceException));
         }
 
+        public BrowserCommandResult<bool> InitializeTestMode()
+        {
+            return this.Execute(GetOptions("Initialize Unified Interface TestMode"), driver =>
+            {
+                var uri = driver.Url;
+
+                if (!uri.Contains("flags=testmode=true"))
+                {
+                    var queryParams = "&flags=testmode=true";
+                    var newUri = uri + queryParams;
+
+                    driver.Navigate().GoToUrl(newUri);
+
+                    driver.WaitForPageToLoad();
+                    driver.WaitForTransaction();
+                }
+
+                return true;
+            });
+        }
+
+
         public string[] OnlineDomains { get; set; }
 
         #region Login
@@ -217,6 +239,11 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 
                     driver.WaitForTransaction();
 
+                    if (Browser.Options.UCITestMode)
+                    {
+                        InitializeTestMode();
+                    }
+
                     return true;
                 }
 
@@ -227,6 +254,11 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                     tileContainer.FindElement(By.XPath(AppElements.Xpath[AppReference.Navigation.UCIAppTile].Replace("[NAME]", appName))).Click(true);
 
                     driver.WaitForTransaction();
+
+                    if (Browser.Options.UCITestMode)
+                    {
+                        InitializeTestMode();
+                    }
 
                 }
                 else
@@ -240,6 +272,11 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                         tileContainer.FindElement(By.XPath(AppElements.Xpath[AppReference.Navigation.UCIAppTile].Replace("[NAME]", appName))).Click(true);
 
                         driver.WaitForTransaction();
+
+                        if (Browser.Options.UCITestMode)
+                        {
+                            InitializeTestMode();
+                        }
                     }
                     else
                         throw new InvalidOperationException($"App Name {appName} not found.");

--- a/Microsoft.Dynamics365.UIAutomation.Browser/BrowserOptions.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Browser/BrowserOptions.cs
@@ -29,6 +29,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Browser
             this.HideDiagnosticWindow = true;
             this.Height = null;
             this.Width = null;
+            this.UCITestMode = true;
         }
 
         public BrowserType RemoteBrowserType { get; set; }
@@ -61,6 +62,12 @@ namespace Microsoft.Dynamics365.UIAutomation.Browser
         /// Gets or sets the browser width when Both <see cref="StartMaximized"/> is <see langword="false" />. Both <see cref="Height"/> and <see cref="Width"/> must be set.
         /// </summary>
         public int? Width { get; set; }
+        /// <summary>
+        /// Gets or sets the TestMode flag for the UnifiedInterface. This flag should not be used when capturing performance measurements
+        /// This flag introduces full loading patterns that are not typical of a normal user experience, but are required for full DOM interaction.
+        /// Please raise any issues with this TestMode being enabled to the Microsoft/EasyRepro community on GitHub for review.
+        /// </summary>
+        public bool UCITestMode { get; set; }
 
         public virtual ChromeOptions ToChrome()
         {

--- a/Microsoft.Dynamics365.UIAutomation.Sample/TestSettings.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Sample/TestSettings.cs
@@ -26,7 +26,8 @@ namespace Microsoft.Dynamics365.UIAutomation.Sample
             UserAgent = false,
             DefaultThinkTime = 2000,
             RemoteBrowserType = (BrowserType)Enum.Parse(typeof(BrowserType), RemoteType),
-            RemoteHubServer = new Uri(RemoteHubServerURL)
+            RemoteHubServer = new Uri(RemoteHubServerURL),
+            UCITestMode = true
         };
 
         public static string GetRandomString(int minLen, int maxLen)

--- a/Microsoft.Dynamics365.UIAutomation.Sample/UCI/Read/OpenAccount.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Sample/UCI/Read/OpenAccount.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Sample.UCI
 
                 xrmApp.Navigation.OpenSubArea("Sales", "Accounts");
                 
-                xrmApp.Grid.Search("04");
+                xrmApp.Grid.Search("Adventure");
 
                 xrmApp.Grid.OpenRecord(0);
 


### PR DESCRIPTION
 This should be disabled if using EasyRepro for performance testing (e.g. faster form load times).

If this option is disabled, you may experience issues trying to use APIs such as SetValue, GetValue - due to a rendering pattern in the Unified Interface that does not render DOM elements that are not immediately visible on screen.