### PR TITLE
Add methods to retrieve list of areas and subareas, with tests for each

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api/Pages/Navigation.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api/Pages/Navigation.cs
@@ -474,6 +474,52 @@ namespace Microsoft.Dynamics365.UIAutomation.Api
             });
         }
 
+        /// <summary>
+        /// Retrieves a Dictionary containing all of the Areas on the main menu
+        /// </summary>
+        /// <param name="thinkTime">Used to simulate a wait time between human interactions. The Default is 2 seconds.</param>
+        /// <example>xrmBrowser.Navigation.GetAreas();</example>
+
+        public BrowserCommandResult<Dictionary<string, IWebElement>> GetAreas(int thinkTime = Constants.DefaultThinkTime)
+        {
+            Browser.ThinkTime(thinkTime);
+
+            return this.Execute(GetOptions($"Get Areas"), driver =>
+            {
+                var areas = OpenMenu().Value;
+
+                driver.WaitForPageToLoad();
+
+                return areas;
+            });
+        }
+
+        /// <summary>
+        /// Retrieves a list of the sub areas within a specified area
+        /// </summary>
+        /// <param name="area">The area whose subareas you want to check</param>
+        /// <param name="thinkTime">Used to simulate a wait time between human interactions. The Default is 2 seconds.</param>
+        /// <example>xrmBrowser.Navigation.GetSubAreas("Sales"); - returns all of the subareas in the Sales area</example>
+        public BrowserCommandResult<List<KeyValuePair<string, IWebElement>>> GetSubAreas(string area, int thinkTime = Constants.DefaultThinkTime)
+        {
+            Browser.ThinkTime(thinkTime);
+
+            return this.Execute(GetOptions($"Get SubAreas"), driver =>
+            {
+                area = area.ToLower();
+
+                var areas = OpenMenu().Value;
+
+                if (!areas.ContainsKey(area))
+                {
+                    throw new InvalidOperationException($"No area with the name '{area}' exists.");
+                }
+
+                var subAreas = OpenSubMenu(areas[area]).Value;
+
+                return subAreas;
+            });
+        }
 
         /// <summary>
         /// SignOut

--- a/Microsoft.Dynamics365.UIAutomation.Sample/Microsoft.Dynamics365.UIAutomation.Sample.csproj
+++ b/Microsoft.Dynamics365.UIAutomation.Sample/Microsoft.Dynamics365.UIAutomation.Sample.csproj
@@ -131,6 +131,7 @@
     <Compile Include="Web\Entity\SubGrid.cs" />
     <Compile Include="Web\Entity\TestBase.cs" />
     <Compile Include="Web\Entity\Account.cs" />
+    <Compile Include="Web\Navigation\AreasAndSubAreas.cs" />
     <Compile Include="Web\ValidationTests\CreateUser.cs" />
     <Compile Include="Web\ValidationTests\CreateWorkflow.cs" />
     <Compile Include="Web\ValidationTests\OpenO365App.cs" />

--- a/Microsoft.Dynamics365.UIAutomation.Sample/Web/Navigation/AreasAndSubAreas.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Sample/Web/Navigation/AreasAndSubAreas.cs
@@ -1,0 +1,90 @@
+﻿using Microsoft.Dynamics365.UIAutomation.Browser;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security;
+using OpenQA.Selenium;
+
+namespace Microsoft.Dynamics365.UIAutomation.Sample.Web.Navigation
+{
+    [TestClass]
+    public class AreasAndSubAreas
+    {
+        private readonly SecureString _username = System.Configuration.ConfigurationManager.AppSettings["OnlineUsername"].ToSecureString();
+        private readonly SecureString _password = System.Configuration.ConfigurationManager.AppSettings["OnlinePassword"].ToSecureString();
+        private readonly Uri _xrmUri = new Uri(System.Configuration.ConfigurationManager.AppSettings["OnlineCrmUrl"]);
+
+        [TestMethod]
+        public void CheckSubAreasAvailableWithinSalesArea()
+        {
+            using (var xrmBrowser = new Api.Browser(TestSettings.Options))
+            {
+                xrmBrowser.LoginPage.Login(_xrmUri, _username, _password);
+                xrmBrowser.ThinkTime(500);
+
+                List<string> expectedSubAreas = new List<string> { "leads", "opportunities", "competitors" };
+
+                List<KeyValuePair<string, IWebElement>> subareas = xrmBrowser.Navigation.GetSubAreas("Sales");
+                List<string> actualSubAreas = new List<string>();
+                foreach (var subarea in subareas)
+                {
+                  actualSubAreas.Add(subarea.Key);  
+                }
+
+                Assert.IsTrue(TwoListsAreTheSame(expectedSubAreas, actualSubAreas));
+            }
+        }
+
+        [TestMethod]
+        public void CheckAreasAvailableOnMenu()
+        {
+            using (var xrmBrowser = new Api.Browser(TestSettings.Options))
+            {
+                xrmBrowser.LoginPage.Login(_xrmUri, _username, _password);
+                xrmBrowser.ThinkTime(500);
+
+                Dictionary<string, IWebElement> areas = xrmBrowser.Navigation.GetAreas();
+
+                List<string> expectedAreas = new List<string> {"sales", "workplace", "training", "settings"};
+
+                List<string> actualAreas = new List<string>();
+
+                foreach (var subarea in areas)
+                {
+                    actualAreas.Add(subarea.Key);
+                }
+
+                Assert.IsTrue(TwoListsAreTheSame(expectedAreas, actualAreas));
+            }
+        }
+
+        private bool TwoListsAreTheSame(List<string> expectedList, List<string> actualList)
+        {
+            bool result = true;
+
+            if (actualList.Except(expectedList).Any())
+            {
+                result = false;
+                Console.WriteLine(@"These items were in the expected list but not the actual list.");
+                
+                foreach (var listItem in expectedList.Except(actualList))
+                {
+                    Console.WriteLine(listItem);
+                }
+            }
+
+            if (actualList.Except(expectedList).Any())
+            {
+                result = false;
+                Console.WriteLine(@"These items were in the actual list but not the expected list.");
+
+                foreach (var listItem in actualList.Except(expectedList))
+                {
+                    Console.WriteLine(listItem);
+                }
+            }
+            return result;
+        }
+    }
+}


### PR DESCRIPTION
Two new methods in the Navigate class.
GetSubAreas(string area) retrieves all of the subareas for a specifed area
GetAreas retrieves a list of all areas available to the user
New Unit Test class with a test for each method, showing how to compare the expected areas or subareas with the actual areas or subareas.
Will fix #566 Add methods to retrieve lists of Areas and SubAreas

Further refactoring could include using these new methods elsewhere in the Navigate Class where the code is interacting with areas/subareas such as 'OpenSubArea'.

Tested in the Web client, not UCI.