### PR TITLE
Entity.GetValue: Throw correct exception when field has different type.

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api/Pages/Entity.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api/Pages/Entity.cs
@@ -1222,10 +1222,13 @@ namespace Microsoft.Dynamics365.UIAutomation.Api
                     {
                         text = fieldElement.FindElement(By.TagName("textarea")).GetAttribute("value");
                     }
-                    else
+                    else if (fieldElement.FindElements(By.TagName("input")).Count > 0)
                     {
                         text = fieldElement.FindElement(By.TagName("input")).GetAttribute("value");
-
+                    } 
+                    else
+                    {
+                        throw new InvalidOperationException($"Field: {field} is not a Text/Description field");
                     }
                 }
                 else


### PR DESCRIPTION
Throw `InvalidOperationException` with helpful message instead of `NoSuchElementException` when using `GetValue` on incorrect field type.