### PR TITLE
Updating RecordWall.WEBTestAddTask() test and underlying ActivityFeed…

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api/Pages/ActivityFeed.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api/Pages/ActivityFeed.cs
@@ -232,6 +232,10 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.Pages
                 this.SetValue(Elements.ElementId[Reference.ActivityFeed.ActivityTaskDescriptionId], description);
                 this.SetCalenderValue(Elements.ElementId[Reference.ActivityFeed.ActivityAddTaskDueDateId], dueDate.ToShortDateString());
                 this.SetCalenderValue(Elements.ElementId[Reference.ActivityFeed.ActivityAddTaskDueTimeId], dueDate.ToShortTimeString());
+
+                // Update prioritycode id value for unique declaration in AddTask
+                priority.Name = "quickCreateActivity4212controlId_[NAME]_d".Replace("[NAME]", priority.Name);
+
                 this.SetValue(priority);
 
                 driver.ClickWhenAvailable(By.XPath(Elements.Xpath[Reference.ActivityFeed.ActivityTaskOk]));

--- a/Microsoft.Dynamics365.UIAutomation.Sample/Web/Entity/RecordWall.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Sample/Web/Entity/RecordWall.cs
@@ -83,7 +83,11 @@ namespace Microsoft.Dynamics365.UIAutomation.Sample.Web
         {
             if (!HasData) return;
             XrmTestBrowser.ActivityFeed.SelectTab(Api.Pages.ActivityFeed.Tab.Activities);
-            XrmTestBrowser.ActivityFeed.AddTask("Schedule an appointment", "Capture preliminary customer and product information.", DateTime.Now, new OptionSet { Name = "quickCreateActivity4212controlId_prioritycode_d", Value = "Normal" });
+            XrmTestBrowser.ActivityFeed.AddTask("Schedule an appointment", "Capture preliminary customer and product information.", DateTime.Now, new OptionSet { Name = "prioritycode", Value = "High" });
+
+            DateTime futureDate = DateTime.Parse("10/31/2021 5:50 am");            
+            XrmTestBrowser.ActivityFeed.AddTask("Schedule an appointment", "Capture preliminary customer and product information.", futureDate , new OptionSet { Name = "prioritycode", Value = "Low" });
+
             XrmTestBrowser.ThinkTime(4000); 
         }
 


### PR DESCRIPTION
….AddTask() methods to follow expected EasyRepro use-case.

### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (updates to documentation, formatting, etc.)

### Description
<!--- Describe your changes -->

Made adjustments to WEBTestAddTask based on changes to ActviityFeed.AddTask() method.
User should only be required to input expected schema name of the field (e.g "prioritycode") and under the covers we translate that into the expected element target.

Updated WEBTestAddTask with an example of how to supply a DateTime value other than DateTime.Now()

### Issues addressed
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This should make the method and test case much easier, and less confusing in relation to other EasyRepro methods.

### All submissions:

- [X] My code follows the code style of this project.
- [X] Do existing samples that are effected by this change still run?
- [ ] I have added samples for new functionality. 
- [ ] I raise detailed error messages when possible.
- [X] My code does not rely on labels that have the option to be hidden.

### Which browsers was this tested on?
<!--- Should be tested on Chrome, Firefox, and IE. -->
- [X] Chrome
- [ ] Firefox
- [ ] IE
- [ ] Edge
