### PR TITLE
Return CommandBar Values and debug error fix for UCI

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/Elements/CommandBar.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/Elements/CommandBar.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 using Microsoft.Dynamics365.UIAutomation.Browser;
+using System.Collections.Generic;
 
 namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 {
@@ -24,5 +25,18 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         }
 
 
+        /// <summary>
+        /// Returns the values of CommandBar objects
+        /// </summary>
+        /// <param name="includeMoreCommandsValues">Flag to determine whether values should be returned from the more commands menu</param>
+        /// <param name="thinkTime">Used to simulate a wait time between human interactions. The Default is 2 seconds.</param>
+        /// <example>xrmApp.CommandBar.GetCommandValues(true);</example>
+        public BrowserCommandResult<List<string>> GetCommandValues(bool includeMoreCommandsValues = false, int thinkTime = Constants.DefaultThinkTime)
+        {
+            List<string> commandValues = new List<string>();
+            commandValues = _client.GetCommandValues(includeMoreCommandsValues, thinkTime);
+
+            return commandValues;
+        }
     }
 }

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/Elements/OnlineLogin.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/Elements/OnlineLogin.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 
             if (_client.Browser.Options.UCITestMode)
             {
-                _client.InitializeTestMode();
+                _client.InitializeTestMode(true);
             }
         }
 
@@ -44,7 +44,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 
             if (_client.Browser.Options.UCITestMode)
             {
-                _client.InitializeTestMode();
+                _client.InitializeTestMode(true);
             }
         }
 

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 typeof(NoSuchElementException), typeof(StaleElementReferenceException));
         }
 
-        internal BrowserCommandResult<bool> InitializeTestMode()
+        internal BrowserCommandResult<bool> InitializeTestMode(bool onlineLoginPath = false)
         {
             return this.Execute(GetOptions("Initialize Unified Interface TestMode"), driver =>
             {
@@ -49,7 +49,11 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                     driver.Navigate().GoToUrl(testModeUri);
 
                     driver.WaitForPageToLoad();
-                    driver.WaitForTransaction();
+
+                    if (!onlineLoginPath)
+                    {
+                        driver.WaitForTransaction();
+                    }
                 }
 
                 return true;
@@ -1048,6 +1052,103 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 return true;
             });
         }
+
+        /// <summary>
+        /// Returns the values of CommandBar objects
+        /// </summary>
+        /// <param name="moreCommands">The moreCommands</param>
+        /// <param name="thinkTime">Used to simulate a wait time between human interactions. The Default is 2 seconds.</param>
+        /// <example>xrmBrowser.Related.ClickCommand("ADD NEW CASE");</example>
+        internal BrowserCommandResult<List<string>> GetCommandValues(bool includeMoreCommandsValues = false, int thinkTime = Constants.DefaultThinkTime)
+        {
+            Browser.ThinkTime(thinkTime);
+
+            return this.Execute(GetOptions("Get CommandBar Command Count"), driver =>
+            {
+                IWebElement ribbon = null;
+                List<string> commandValues = new List<string>();
+
+                //Find the button in the CommandBar
+                if (driver.HasElement(By.XPath(AppElements.Xpath[AppReference.CommandBar.Container])))
+                    ribbon = driver.FindElement(By.XPath(AppElements.Xpath[AppReference.CommandBar.Container]));
+
+                if (ribbon == null)
+                {
+                    if (driver.HasElement(By.XPath(AppElements.Xpath[AppReference.CommandBar.ContainerGrid])))
+                        ribbon = driver.FindElement(By.XPath(AppElements.Xpath[AppReference.CommandBar.ContainerGrid]));
+                    else
+                        throw new InvalidOperationException("Unable to find the ribbon.");
+                }
+
+                //Get the CommandBar buttons
+                var commandBarItems = ribbon.FindElements(By.TagName("li"));
+
+                foreach (var value in commandBarItems)
+                {
+                    if (value.Text != "")
+                    {
+                        string commandText = value.Text.ToString();
+
+                        if (commandText.Contains("\r\n"))
+                        {
+                            commandText = commandText.Substring(0, commandText.IndexOf("\r\n"));
+                        }
+
+                        if (!commandValues.Contains(value.Text))
+                        {
+                            commandValues.Add(commandText);
+                        }
+                    }
+                }
+
+                if (includeMoreCommandsValues)
+                {
+                    if (commandBarItems.Any(x => x.GetAttribute("aria-label").Equals("More Commands", StringComparison.OrdinalIgnoreCase)))
+                    {
+                        //Click More Commands Button
+                        commandBarItems.FirstOrDefault(x => x.GetAttribute("aria-label").Equals("More Commands", StringComparison.OrdinalIgnoreCase)).Click(true);
+                        driver.WaitForTransaction();
+
+                        //Click the button
+                        var moreCommandsMenu = driver.FindElement(By.XPath(AppElements.Xpath[AppReference.CommandBar.MoreCommandsMenu]));
+
+                        if (moreCommandsMenu != null)
+                        {
+                            var moreCommandsItems = moreCommandsMenu.FindElements(By.TagName("li"));
+
+                            foreach (var value in moreCommandsItems)
+                            {
+                                if (value.Text != "")
+                                {
+                                    string commandText = value.Text.ToString();
+
+                                    if (commandText.Contains("\r\n"))
+                                    {
+                                        commandText = commandText.Substring(0, commandText.IndexOf("\r\n"));
+                                    }
+
+                                    if (!commandValues.Contains(value.Text))
+                                    {
+                                        commandValues.Add(commandText);
+                                    }
+                                }
+                            }
+                        }
+                        else
+                        {
+                            throw new InvalidOperationException("Unable to locate the 'More Commands' menu");
+                        }
+                    }
+                    else
+                    {
+                        throw new InvalidOperationException("No button matching 'More Commands' exists in the CommandBar");
+                    }
+                }
+
+                return commandValues;
+            });
+        }
+       
         #endregion
 
         #region Grid

--- a/Microsoft.Dynamics365.UIAutomation.Api/Pages/CommandBar.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api/Pages/CommandBar.cs
@@ -2,6 +2,9 @@
 // Licensed under the MIT license.
 
 using Microsoft.Dynamics365.UIAutomation.Browser;
+using OpenQA.Selenium;
+using System;
+using System.Collections.Generic;
 
 namespace Microsoft.Dynamics365.UIAutomation.Api
 {
@@ -25,6 +28,57 @@ namespace Microsoft.Dynamics365.UIAutomation.Api
             : base(browser)
         {
             SwitchToDefault();
+        }
+
+        /// <summary>
+        /// Returns the values of CommandBar objects
+        /// </summary>
+        /// <param name="moreCommands">The moreCommands</param>
+        /// <param name="thinkTime">Used to simulate a wait time between human interactions. The Default is 2 seconds.</param>
+        /// <example>xrmBrowser.Related.ClickCommand("ADD NEW CASE");</example>
+        public BrowserCommandResult<List<string>> GetCommandValues(bool includeMoreCommandsValues = false, int thinkTime = Constants.DefaultThinkTime)
+        {
+            Browser.ThinkTime(thinkTime);
+
+            return this.Execute(GetOptions("Get CommandBar Command Count"), driver =>
+            {
+                driver.WaitUntilAvailable(By.XPath(Elements.Xpath[Reference.CommandBar.RibbonManager]), new TimeSpan(0, 0, 5));
+
+                List<string> commandValues = new List<string>();
+
+                var retrieveCommandValues = GetCommands(false).Value;
+
+                foreach (var value in retrieveCommandValues)
+                {
+                    if (value.Text != "")
+                    {
+                        string commandText = value.Text.ToString();
+                        string trimmedCommandText = commandText.Substring(0, commandText.LastIndexOf("\r\n"));
+
+                        commandValues.Add(trimmedCommandText);
+                    }
+                }
+
+                if (includeMoreCommandsValues)
+                {
+                    driver.ClickWhenAvailable(By.XPath(Elements.Xpath[Reference.CommandBar.MoreCommands]));
+
+                    var retrieveMoreCommandsValues = GetCommands(true).Value;
+
+                    foreach (var value in retrieveMoreCommandsValues)
+                    {
+                        if (value.Text != "")
+                        {
+                            string commandText = value.Text.ToString();
+                            string trimmedCommandText = commandText.Substring(0, commandText.LastIndexOf("\r\n")).ToUpper();
+
+                            commandValues.Add(trimmedCommandText);
+                        }
+                    }
+                }
+
+                return commandValues;
+            });
         }
     }
 }

--- a/Microsoft.Dynamics365.UIAutomation.Sample/Microsoft.Dynamics365.UIAutomation.Sample.csproj
+++ b/Microsoft.Dynamics365.UIAutomation.Sample/Microsoft.Dynamics365.UIAutomation.Sample.csproj
@@ -81,6 +81,7 @@
     <Compile Include="SharedAPI\BrowserTests\BrowserTests.cs" />
     <Compile Include="UCI\BusinessProcessFlow\BusinessProcessFlowNextStage.cs" />
     <Compile Include="UCI\BusinessProcessFlow\SwitchBusinessProcessFlow.cs" />
+    <Compile Include="UCI\CommandBar\CommandButton.cs" />
     <Compile Include="UCI\CommandBar\AssignAccount.cs" />
     <Compile Include="UCI\CommandBar\CloseOpportunity.cs" />
     <Compile Include="UCI\CommandBar\DuplicateDetection.cs" />

--- a/Microsoft.Dynamics365.UIAutomation.Sample/UCI/CommandBar/CommandButton.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Sample/UCI/CommandBar/CommandButton.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.Dynamics365.UIAutomation.Api.UCI;
+using Microsoft.Dynamics365.UIAutomation.Browser;
+using System;
+using System.Collections.Generic;
+using System.Security;
+
+namespace Microsoft.Dynamics365.UIAutomation.Sample.UCI
+{
+    [TestClass]
+    public class CommandButton
+    {
+        private readonly SecureString _username = System.Configuration.ConfigurationManager.AppSettings["OnlineUsername"].ToSecureString();
+        private readonly SecureString _password = System.Configuration.ConfigurationManager.AppSettings["OnlinePassword"].ToSecureString();
+        private readonly Uri _xrmUri = new Uri(System.Configuration.ConfigurationManager.AppSettings["OnlineCrmUrl"].ToString());
+
+        [TestMethod]
+        public void UCITestNewCommandBarButton()
+        {
+            var client = new WebClient(TestSettings.Options);
+            using (var xrmApp = new XrmApp(client))
+            {
+                xrmApp.OnlineLogin.Login(_xrmUri, _username, _password);
+
+                xrmApp.Navigation.OpenApp(UCIAppName.Sales);
+
+                xrmApp.Navigation.OpenSubArea("Sales", "Accounts");
+
+                xrmApp.CommandBar.ClickCommand("New");
+                xrmApp.ThinkTime(2000);
+            }
+        }
+
+        [TestMethod]
+        public void UCITestRetrieveCommandBarValues()
+        {
+            var client = new WebClient(TestSettings.Options);
+            using (var xrmApp = new XrmApp(client))
+            {
+                xrmApp.OnlineLogin.Login(_xrmUri, _username, _password);
+
+                xrmApp.Navigation.OpenApp(UCIAppName.Sales);
+
+                xrmApp.Navigation.OpenSubArea("Sales", "Accounts");
+
+                var commandValues = xrmApp.CommandBar.GetCommandValues().Value;
+                int commandCount = commandValues.Count;
+
+                var includeMoreCommandValues = xrmApp.CommandBar.GetCommandValues(true).Value;
+                int totalCommandCount = includeMoreCommandValues.Count;
+
+                xrmApp.ThinkTime(2000);
+
+            }
+        }
+    }
+}

--- a/Microsoft.Dynamics365.UIAutomation.Sample/Web/CommandBar/CommandButton.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Sample/Web/CommandBar/CommandButton.cs
@@ -5,6 +5,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.Dynamics365.UIAutomation.Api;
 using Microsoft.Dynamics365.UIAutomation.Browser;
 using System;
+using System.Collections.Generic;
 using System.Security;
 
 namespace Microsoft.Dynamics365.UIAutomation.Sample.Web
@@ -27,6 +28,27 @@ namespace Microsoft.Dynamics365.UIAutomation.Sample.Web
                 xrmBrowser.Navigation.OpenSubArea("Sales", "Accounts");
 
                 xrmBrowser.CommandBar.ClickCommand("New");
+                xrmBrowser.ThinkTime(2000);
+
+            }
+        }
+
+        [TestMethod]
+        public void WEBTestRetrieveCommandBarValues()
+        {
+            using (var xrmBrowser = new Api.Browser(TestSettings.Options))
+            {
+                xrmBrowser.LoginPage.Login(_xrmUri, _username, _password);
+                xrmBrowser.GuidedHelp.CloseGuidedHelp();
+
+                xrmBrowser.Navigation.OpenSubArea("Sales", "Accounts");
+
+                var commandValues = xrmBrowser.CommandBar.GetCommandValues().Value;
+                int commandCount = commandValues.Count;
+
+                var includeMoreCommandValues = xrmBrowser.CommandBar.GetCommandValues(true).Value;
+                int totalCommandCount = includeMoreCommandValues.Count;
+
                 xrmBrowser.ThinkTime(2000);
 
             }


### PR DESCRIPTION
### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Other (updates to documentation, formatting, etc.)

### Description
<!--- Describe your changes -->

Added method for WebClient and UCI - CommandBar.GetCommandValues();
- Includes a bool flag on whether to return items from the moreCommands menu list.
- Can assign the returned value and retrieve total count if desired

Added a flag to remove WaitForTransaction() from the InitializeTestMode() method if entering from the OnlineLogin path.

### Issues addressed
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Issue #565 
Issue #571 

### All submissions:

- [x] My code follows the code style of this project.
- [x] Do existing samples that are effected by this change still run?
- [x] I have added samples for new functionality. 
- [x] I raise detailed error messages when possible.
- [x] My code does not rely on labels that have the option to be hidden.

### Which browsers was this tested on?
<!--- Should be tested on Chrome, Firefox, and IE. -->
- [x] Chrome
- [ ] Firefox
- [ ] IE
- [ ] Edge
