### PR TITLE
Add check to only set Time value if Time field is present

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api/Pages/ActivityFeed.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api/Pages/ActivityFeed.cs
@@ -231,7 +231,11 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.Pages
                 this.SetValue(Elements.ElementId[Reference.ActivityFeed.ActivityTaskSubjectId], subject);
                 this.SetValue(Elements.ElementId[Reference.ActivityFeed.ActivityTaskDescriptionId], description);
                 this.SetCalenderValue(Elements.ElementId[Reference.ActivityFeed.ActivityAddTaskDueDateId], dueDate.ToShortDateString());
-                this.SetCalenderValue(Elements.ElementId[Reference.ActivityFeed.ActivityAddTaskDueTimeId], dueDate.ToShortTimeString());
+
+                if (driver.HasElement(By.Id(Elements.ElementId[Reference.ActivityFeed.ActivityAddTaskDueTimeId])))
+                {
+                    this.SetCalenderValue(Elements.ElementId[Reference.ActivityFeed.ActivityAddTaskDueTimeId], dueDate.ToShortTimeString());
+                }
 
                 // Update prioritycode id value for unique declaration in AddTask
                 priority.Name = "quickCreateActivity4212controlId_[NAME]_d".Replace("[NAME]", priority.Name);

--- a/Microsoft.Dynamics365.UIAutomation.Sample/Web/Entity/RecordWall.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Sample/Web/Entity/RecordWall.cs
@@ -85,8 +85,11 @@ namespace Microsoft.Dynamics365.UIAutomation.Sample.Web
             XrmTestBrowser.ActivityFeed.SelectTab(Api.Pages.ActivityFeed.Tab.Activities);
             XrmTestBrowser.ActivityFeed.AddTask("Schedule an appointment", "Capture preliminary customer and product information.", DateTime.Now, new OptionSet { Name = "prioritycode", Value = "High" });
 
-            DateTime futureDate = DateTime.Parse("10/31/2021 5:50 am");            
+            DateTime futureDate = DateTime.Parse("10/31/2021");            
             XrmTestBrowser.ActivityFeed.AddTask("Schedule an appointment", "Capture preliminary customer and product information.", futureDate , new OptionSet { Name = "prioritycode", Value = "Low" });
+
+            DateTime shortDate = new DateTime(2021, 5, 1);
+            XrmTestBrowser.ActivityFeed.AddTask("Schedule an appointment", "Capture preliminary customer and product information.", shortDate, new OptionSet { Name = "prioritycode", Value = "Low" });
 
             XrmTestBrowser.ThinkTime(4000); 
         }


### PR DESCRIPTION
### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (updates to documentation, formatting, etc.)

### Description
<!--- Describe your changes -->

Adding a check to only set the Time value if the Time field is present

### Issues addressed
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Issue #520 

### All submissions:

- [x] My code follows the code style of this project.
- [x] Do existing samples that are effected by this change still run?
- [ ] I have added samples for new functionality. 
- [ ] I raise detailed error messages when possible.
- [x] My code does not rely on labels that have the option to be hidden.

### Which browsers was this tested on?
<!--- Should be tested on Chrome, Firefox, and IE. -->
- [x] Chrome
- [ ] Firefox
- [ ] IE
- [ ] Edge
