### PR TITLE
Issues with WebClient Lookup fields and Firefox browser

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/Microsoft.Dynamics365.UIAutomation.Api.UCI.csproj
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/Microsoft.Dynamics365.UIAutomation.Api.UCI.csproj
@@ -99,7 +99,9 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Selenium.Chrome.WebDriver.74.0.0\build\Selenium.Chrome.WebDriver.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Selenium.Chrome.WebDriver.74.0.0\build\Selenium.Chrome.WebDriver.targets'))" />
+    <Error Condition="!Exists('..\packages\Selenium.Firefox.WebDriver.0.24.0\build\Selenium.Firefox.WebDriver.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Selenium.Firefox.WebDriver.0.24.0\build\Selenium.Firefox.WebDriver.targets'))" />
   </Target>
+  <Import Project="..\packages\Selenium.Firefox.WebDriver.0.24.0\build\Selenium.Firefox.WebDriver.targets" Condition="Exists('..\packages\Selenium.Firefox.WebDriver.0.24.0\build\Selenium.Firefox.WebDriver.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/packages.config
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/packages.config
@@ -2,6 +2,7 @@
 <packages>
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net46" />
   <package id="Selenium.Chrome.WebDriver" version="74.0.0" targetFramework="net46" />
+  <package id="Selenium.Firefox.WebDriver" version="0.24.0" targetFramework="net46" />
   <package id="Selenium.Support" version="3.141.0" targetFramework="net46" />
   <package id="Selenium.WebDriver" version="3.141.0" targetFramework="net46" />
 </packages>

--- a/Microsoft.Dynamics365.UIAutomation.Api/Microsoft.Dynamics365.UIAutomation.Api.csproj
+++ b/Microsoft.Dynamics365.UIAutomation.Api/Microsoft.Dynamics365.UIAutomation.Api.csproj
@@ -130,7 +130,9 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Selenium.Chrome.WebDriver.74.0.0\build\Selenium.Chrome.WebDriver.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Selenium.Chrome.WebDriver.74.0.0\build\Selenium.Chrome.WebDriver.targets'))" />
+    <Error Condition="!Exists('..\packages\Selenium.Firefox.WebDriver.0.24.0\build\Selenium.Firefox.WebDriver.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Selenium.Firefox.WebDriver.0.24.0\build\Selenium.Firefox.WebDriver.targets'))" />
   </Target>
+  <Import Project="..\packages\Selenium.Firefox.WebDriver.0.24.0\build\Selenium.Firefox.WebDriver.targets" Condition="Exists('..\packages\Selenium.Firefox.WebDriver.0.24.0\build\Selenium.Firefox.WebDriver.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Microsoft.Dynamics365.UIAutomation.Api/Pages/Entity.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api/Pages/Entity.cs
@@ -476,6 +476,8 @@ namespace Microsoft.Dynamics365.UIAutomation.Api
 
                         SwitchToDialog();
 
+                        Browser.ThinkTime(500);
+
                         driver.WaitUntilAvailable(By.XPath(Elements.Xpath[Reference.LookUp.Remove])).Click(true);
 
                     }

--- a/Microsoft.Dynamics365.UIAutomation.Api/Pages/GuidedHelp.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api/Pages/GuidedHelp.cs
@@ -28,9 +28,17 @@ namespace Microsoft.Dynamics365.UIAutomation.Api
             get
             {
                 bool isGuidedHelpEnabled = false;
-                bool.TryParse(
-                    this.Browser.Driver.ExecuteScript("return Xrm.Internal.isFeatureEnabled('FCB.GuidedHelp') && Xrm.Internal.isGuidedHelpEnabledForUser();").ToString(),
-                    out isGuidedHelpEnabled);
+                try
+                {
+                    bool.TryParse(
+                        this.Browser.Driver.ExecuteScript("return Xrm.Internal.isFeatureEnabled('FCB.GuidedHelp') && Xrm.Internal.isGuidedHelpEnabledForUser();").ToString(),
+                        out isGuidedHelpEnabled);
+                }
+                catch (System.NullReferenceException)
+                {
+                    // do nothing
+                }
+
 
                 return isGuidedHelpEnabled;
             }

--- a/Microsoft.Dynamics365.UIAutomation.Api/Pages/Navigation.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api/Pages/Navigation.cs
@@ -171,12 +171,12 @@ namespace Microsoft.Dynamics365.UIAutomation.Api
             {
                 var dictionary = new Dictionary<string, IWebElement>();
 
+                driver.WaitUntilAvailable(By.ClassName(Elements.CssClass[Reference.Navigation.TopLevelItem]));
+
                 var topItem = driver.FindElements(By.ClassName(Elements.CssClass[Reference.Navigation.TopLevelItem])).FirstOrDefault();
                 topItem?.FindElement(By.Name(Elements.Name[Reference.Navigation.HomeTab])).Click();
 
-                //  driver.ClickWhenAvailable(By.XPath(Elements.Xpath[Reference.Navigation.HomeTab]));
-
-                Thread.Sleep(1000);
+                driver.WaitUntilAvailable(By.XPath(Elements.Xpath[Reference.Navigation.ActionGroup]));
 
                 var element = driver.FindElement(By.XPath(Elements.Xpath[Reference.Navigation.ActionGroup]));
                 var subItems = element.FindElements(By.ClassName(Elements.CssClass[Reference.Navigation.ActionButtonContainer]));

--- a/Microsoft.Dynamics365.UIAutomation.Api/XrmPage.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api/XrmPage.cs
@@ -426,7 +426,8 @@ namespace Microsoft.Dynamics365.UIAutomation.Api
                     if (input.FindElement(By.ClassName(Elements.CssClass[Reference.SetValue.LookupRenderClass])) == null)
                         throw new InvalidOperationException($"Field: {field} is not lookup");
 
-                    input.FindElement(By.ClassName(Elements.CssClass[Reference.SetValue.LookupRenderClass])).Click();
+                    var lookupIcon = input.FindElement(By.ClassName("Lookup_RenderButton_td"));
+                    lookupIcon.Click();
 
                     var dialogName = $"Dialog_{field}_IMenu";
                     var dialog = driver.WaitUntilAvailable(By.Id(dialogName));

--- a/Microsoft.Dynamics365.UIAutomation.Api/XrmPage.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api/XrmPage.cs
@@ -427,7 +427,8 @@ namespace Microsoft.Dynamics365.UIAutomation.Api
                         throw new InvalidOperationException($"Field: {field} is not lookup");
 
                     var lookupIcon = input.FindElement(By.ClassName("Lookup_RenderButton_td"));
-                    lookupIcon.Click();
+                    lookupIcon.Hover(driver, true);
+                    lookupIcon.Click(true);
 
                     var dialogName = $"Dialog_{field}_IMenu";
                     var dialog = driver.WaitUntilAvailable(By.Id(dialogName));

--- a/Microsoft.Dynamics365.UIAutomation.Api/packages.config
+++ b/Microsoft.Dynamics365.UIAutomation.Api/packages.config
@@ -2,6 +2,7 @@
 <packages>
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net461" />
   <package id="Selenium.Chrome.WebDriver" version="74.0.0" targetFramework="net46" />
+  <package id="Selenium.Firefox.WebDriver" version="0.24.0" targetFramework="net46" />
   <package id="Selenium.Support" version="3.141.0" targetFramework="net46" />
   <package id="Selenium.WebDriver" version="3.141.0" targetFramework="net46" />
 </packages>

--- a/Microsoft.Dynamics365.UIAutomation.Browser/Microsoft.Dynamics365.UIAutomation.Browser.csproj
+++ b/Microsoft.Dynamics365.UIAutomation.Browser/Microsoft.Dynamics365.UIAutomation.Browser.csproj
@@ -108,7 +108,9 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Selenium.Chrome.WebDriver.74.0.0\build\Selenium.Chrome.WebDriver.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Selenium.Chrome.WebDriver.74.0.0\build\Selenium.Chrome.WebDriver.targets'))" />
+    <Error Condition="!Exists('..\packages\Selenium.Firefox.WebDriver.0.24.0\build\Selenium.Firefox.WebDriver.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Selenium.Firefox.WebDriver.0.24.0\build\Selenium.Firefox.WebDriver.targets'))" />
   </Target>
+  <Import Project="..\packages\Selenium.Firefox.WebDriver.0.24.0\build\Selenium.Firefox.WebDriver.targets" Condition="Exists('..\packages\Selenium.Firefox.WebDriver.0.24.0\build\Selenium.Firefox.WebDriver.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Microsoft.Dynamics365.UIAutomation.Browser/packages.config
+++ b/Microsoft.Dynamics365.UIAutomation.Browser/packages.config
@@ -4,6 +4,7 @@
 <packages>
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net46" />
   <package id="Selenium.Chrome.WebDriver" version="74.0.0" targetFramework="net46" />
+  <package id="Selenium.Firefox.WebDriver" version="0.24.0" targetFramework="net46" />
   <package id="Selenium.Support" version="3.141.0" targetFramework="net46" />
   <package id="Selenium.WebDriver" version="3.141.0" targetFramework="net46" />
 </packages>

--- a/Microsoft.Dynamics365.UIAutomation.Sample/Microsoft.Dynamics365.UIAutomation.Sample.csproj
+++ b/Microsoft.Dynamics365.UIAutomation.Sample/Microsoft.Dynamics365.UIAutomation.Sample.csproj
@@ -261,7 +261,9 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Selenium.Chrome.WebDriver.74.0.0\build\Selenium.Chrome.WebDriver.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Selenium.Chrome.WebDriver.74.0.0\build\Selenium.Chrome.WebDriver.targets'))" />
+    <Error Condition="!Exists('..\packages\Selenium.Firefox.WebDriver.0.24.0\build\Selenium.Firefox.WebDriver.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Selenium.Firefox.WebDriver.0.24.0\build\Selenium.Firefox.WebDriver.targets'))" />
   </Target>
+  <Import Project="..\packages\Selenium.Firefox.WebDriver.0.24.0\build\Selenium.Firefox.WebDriver.targets" Condition="Exists('..\packages\Selenium.Firefox.WebDriver.0.24.0\build\Selenium.Firefox.WebDriver.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Microsoft.Dynamics365.UIAutomation.Sample/Web/Update/UpdateAccount.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Sample/Web/Update/UpdateAccount.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Sample.Web
             using (var xrmBrowser = new Api.Browser(TestSettings.Options))
             {
                 xrmBrowser.LoginPage.Login(_xrmUri, _username, _password);
-                xrmBrowser.GuidedHelp.CloseGuidedHelp();
+                xrmBrowser.GuidedHelp.CloseGuidedHelp(5000);
                 xrmBrowser.ThinkTime(500);
                 xrmBrowser.Navigation.OpenSubArea("Sales", "Accounts");
 

--- a/Microsoft.Dynamics365.UIAutomation.Sample/Web/Update/UpdateAccount.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Sample/Web/Update/UpdateAccount.cs
@@ -32,9 +32,34 @@ namespace Microsoft.Dynamics365.UIAutomation.Sample.Web
                 xrmBrowser.ThinkTime(1000);
                 xrmBrowser.Grid.OpenRecord(0);
 
-                xrmBrowser.ThinkTime(1000);
-                xrmBrowser.Entity.SelectLookup("parentaccountid", 0);
+                var parentAccountId = new LookupItem { Name = "parentaccountid", Value = "Litware, Inc. (sample)", Index = 0 };
+
+                // Field Has No Data
+                xrmBrowser.Entity.SelectLookup(parentAccountId);
                 xrmBrowser.Entity.Save();
+                xrmBrowser.ThinkTime(2000);
+
+                // Field Has Existing Data
+                parentAccountId.Index = 1; // Set Index to 1 to select the 2nd record
+                xrmBrowser.Entity.SelectLookup(parentAccountId);
+                xrmBrowser.Entity.Save();
+                xrmBrowser.ThinkTime(2000);
+
+                // Remove value for SetValue tests
+                xrmBrowser.Entity.ClearValue(parentAccountId);
+                xrmBrowser.Entity.Save();
+                xrmBrowser.ThinkTime(2000);
+
+                // Field Has No Data
+                xrmBrowser.Entity.SetValue(parentAccountId);
+                xrmBrowser.Entity.Save();
+                xrmBrowser.ThinkTime(2000);
+
+                // Field Has Existing Data
+                parentAccountId.Value = "Fabrikam, Inc."; // Set the value of parentAccountId to select a different record.
+                xrmBrowser.Entity.SetValue(parentAccountId);
+                xrmBrowser.Entity.Save();
+
                 xrmBrowser.ThinkTime(2000);
             }
         }

--- a/Microsoft.Dynamics365.UIAutomation.Sample/packages.config
+++ b/Microsoft.Dynamics365.UIAutomation.Sample/packages.config
@@ -5,6 +5,7 @@
   <package id="Microsoft.ApplicationInsights" version="2.4.0" targetFramework="net46" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net46" />
   <package id="Selenium.Chrome.WebDriver" version="74.0.0" targetFramework="net46" />
+  <package id="Selenium.Firefox.WebDriver" version="0.24.0" targetFramework="net46" />
   <package id="Selenium.Support" version="3.141.0" targetFramework="net46" />
   <package id="Selenium.WebDriver" version="3.141.0" targetFramework="net46" />
   <package id="System.Diagnostics.DiagnosticSource" version="4.4.0" targetFramework="net46" />


### PR DESCRIPTION
### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (updates to documentation, formatting, etc.)

### Description
<!--- Describe your changes -->

- Updated: SelectLookup(LookupItem field, bool clearFieldValue = true, bool openLookupPage = true)
- New: SelectLookup(LookupItem control)
- Added WaitUntilAvailable checks for OpenSubArea for resiliency on required items
- Added small thinkTime for dialog interaction on lookups
- Introducing Firefox WebDriver 0.24 from test passes

### Issues addressed
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Issues with SetValue, ClearValue and SelectLookup in Firefox browser

### All submissions:

- [x] My code follows the code style of this project.
- [x] Do existing samples that are effected by this change still run?
- [x] I have added samples for new functionality. 
- [ ] I raise detailed error messages when possible.
- [x] My code does not rely on labels that have the option to be hidden.

### Which browsers was this tested on?
<!--- Should be tested on Chrome, Firefox, and IE. -->
- [x] Chrome
- [x] Firefox
- [ ] IE
- [ ] Edge
