### PR TITLE
Fix #602 - Using parent element (tablist) instead of first tab

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/ElementReference.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/ElementReference.cs
@@ -107,7 +107,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             { "Grid_FirstRow", "id(\"gridBodyTable\")/tbody/tr[1]"},
 
             //Entity
-            { "Entity_Form"       , "id(\"tab0\")"},
+            { "Entity_Form"       , "id(\"tablist\")"},
             { "Entity_Close"       , "id(\"closeButton\")"},
             { "Entity_Save"       , "id(\"savefooter_statuscontrol\")"},
             { "Entity_FormSelector", "//*[@data-id=\"form-selector\"]" },


### PR DESCRIPTION
## Bug Report

### Issues should only be created for items related to [covered functionality](https://github.com/microsoft/EasyRepro#crm-functionality-covered). 

### [Not covered](https://github.com/microsoft/EasyRepro#crm-functionality-not-covered) functionality, feature requests, and questions should use the Feature Request or Question templates.


**EasyRepro Version**
  - [ ] Microsoft Dynamics 365 Online Version 8.2 (8.2.x) (DB 8.2.x) online
  - [ ] Microsoft Dynamics 365 Online Version 9.0 (9.0.x) (DB 9.0.x) online
  - [ ] Microsoft Dynamics 365 Online Version 9.0.2 (9.0.2) (DB 9.0.2) online
  - [x] Microsoft Dynamics 365 Online Version 9.1 (9.1.x) (DB 9.1.x) online
  
**UCI or Classic Web**
  - [x] UCI (XrmApp)
  - [ ] Classic Web (XrmBrowser)

**Online or On Premise**
  - [x] Online
  - [ ] On Premise

**Browser**
  - [x] Chrome
  - [ ] Firefox
  - [ ] IE
  - [ ] Edge

**Describe the bug**  
When calling the following code and the form has its first tab disabled. It gets into a timeout as the method waits until the first tab is visible.

- Hide first tab on the account form and publish
- Call 'xrmApp.Entity.OpenEntity("account", Guid.Parse("{GUIDHERE}"));'