### PR TITLE
DateTime error message & SelectTab will use ...

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/AppElementReference.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/AppElementReference.cs
@@ -102,6 +102,8 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             public static string SwitchProcessDialog = "Entity_SwitchProcessDialog";
             public static string TabList = "Entity_TabList";
             public static string Tab = "Entity_Tab";
+            public static string MoreTabs = "Entity_MoreTabs";
+            public static string MoreTabsMenu = "Entity_MoreTabsMenu";
             public static string SubTab = "Entity_SubTab";
             public static string EntityFooter = "Entity_Footer";
             public static string SubGridTitle = "Entity_SubGridTitle";
@@ -331,7 +333,9 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             { "Entity_RecordSetNavCollapseIcon", "//*[contains(@data-id, 'recordSetNavCollapseIcon')]" },
             { "Entity_RecordSetNavCollapseIconParent", "//*[contains(@data-id, 'recordSetNavCollapseIcon')]" },
             { "Entity_TabList", "//ul[@id=\"tablist\"]" },
-            { "Entity_Tab", "//li[@title='{0}' and @role='tab']" },
+            { "Entity_Tab", ".//li[@title='{0}']" },
+            { "Entity_MoreTabs", ".//button[@data-id='more_button']" },
+            { "Entity_MoreTabsMenu", "//div[@id='__flyoutRootNode']" },
             { "Entity_SubTab", "//div[@id=\"__flyoutRootNode\"]//span[text()=\"{0}\"]" },
             { "Entity_FieldControlDateTimeInput","//input[contains(@id,'[FIELD].fieldControl-date-time-input')]" },
             { "Entity_FieldControlDateTimeInputUCI","//input[contains(@data-id,'[FIELD].fieldControl-date-time-input')]" },
@@ -361,7 +365,6 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             { "Entity_OptionsetStatusComboButton", "//div[contains(@id, '[NAME].fieldControl-pickliststatus-comboBox_button')]"},
             { "Entity_OptionsetStatusComboList", "//ul[contains(@id, '[NAME].fieldControl-pickliststatus-comboBox_list')]"},
             { "Entity_OptionsetStatusTextValue", "//span[contains(@id, '[NAME].fieldControl-pickliststatus-comboBox_text-value')]"},
-			
                         
             //CommandBar
             { "Cmd_Container"       , "//ul[contains(@data-lp-id,\"commandbar-Form\")]"},

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -2089,7 +2089,14 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 
                     fieldElement.SendKeys(date.ToString(format));
 
-                    driver.WaitFor(d => fieldElement.GetAttribute("value") == date.ToString(format));
+                    try
+                    {
+                        driver.WaitFor(d => fieldElement.GetAttribute("value") == date.ToString(format));
+                    }
+                    catch (WebDriverTimeoutException ex)
+                    {
+                        throw new InvalidOperationException($"Timeout after 30 seconds. Expected: {date.ToString(format)}. Actual: {fieldElement.GetAttribute("value")}", ex);
+                    }
                     driver.ClearFocus();
                 }
                 else

--- a/Microsoft.Dynamics365.UIAutomation.Browser/Extensions/SeleniumExtensions.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Browser/Extensions/SeleniumExtensions.cs
@@ -273,6 +273,34 @@ namespace Microsoft.Dynamics365.UIAutomation.Browser
             }
         }
 
+        public static bool TryFindElement(this IWebDriver driver, By by, out IWebElement element)
+        {
+            try
+            {
+                element = driver.FindElement(by);
+                return true;
+            }
+            catch (NoSuchElementException)
+            {
+                element = null;
+                return false;
+            }
+        }
+
+        public static bool TryFindElement(this IWebElement element, By by, out IWebElement foundElement)
+        {
+            try
+            {
+                foundElement = element.FindElement(by);
+                return true;
+            }
+            catch (NoSuchElementException)
+            {
+                foundElement = null;
+                return false;
+            }
+        }
+
         public static bool IsVisible(this IWebDriver driver, By by)
         {
             try


### PR DESCRIPTION
…out.

### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Other (updates to documentation, formatting, etc.)

### Description
When setting a date(time) field in the UCI, it will wait until the field's value matches the expected value. If it gets into a timeout (30 seconds), now a meaningful error message is thrown,

When selecting a tab and the tab is in the more tabs (...) section. It will select the tab there.

### Issues addressed
The only error message that will be supplied is during a timeout is: 'Timed out after 30 seconds', It would be better to actually show the error message, especcially when running via Azure DevOps.

Fixed https://github.com/microsoft/EasyRepro/issues/627 by selecting tabs in the more tabs menu.

### All submissions:

- [X] My code follows the code style of this project.
- [X] Do existing samples that are effected by this change still run?
- [ ] I have added samples for new functionality. 
- [X] I raise detailed error messages when possible.
- [X] My code does not rely on labels that have the option to be hidden.

### Which browsers was this tested on?
<!--- Should be tested on Chrome, Firefox, and IE. -->
- [X] Chrome
- [ ] Firefox
- [ ] IE
- [ ] Edge
