### PR TITLE
Add crm12 (France) region to list of supported XrmDomains

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Browser/Constants.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Browser/Constants.cs
@@ -97,7 +97,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Browser
                 ".crm.dynamics.com", ".crm2.dynamics.com", ".crm3.dynamics.com",
                 ".crm4.dynamics.com", "crm5.dynamics.com", "crm6.dynamics.com", "crm7.dynamics.com",
                 ".crm8.dynamics.com", ".crm9.dynamics.com", ".crm10.dynamics.com", ".crm11.dynamics.com",
-                "portal.office.com", "crm2.crmlivetie.com"
+                ".crm12.dynamics.com", "portal.office.com", "crm2.crmlivetie.com"
             };
         }
 


### PR DESCRIPTION
### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Other (updates to documentation, formatting, etc.)

### Description
Adding .crm12 (France) to list of supported XrmDomains

### Issues addressed
Adds support for organizations located in France.

