### PR TITLE
FieldReference: Common inheritance for all controls (LookupItem, Bool…

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/Controls/BooleanItem.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/Controls/BooleanItem.cs
@@ -6,9 +6,8 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
     /// <summary>
     /// Represents a Boolean Item in Dynamics 365.
     /// </summary>
-    public class BooleanItem
+    public class BooleanItem : FieldReference
     {
-        public string Name { get; set; }
         public bool Value { get; set; }
     }
 }

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/Controls/CompositeControl.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/Controls/CompositeControl.cs
@@ -4,10 +4,9 @@ using System.Collections.Generic;
 
 namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 {
-    public class CompositeControl
+    public class CompositeControl : FieldReference
     {
         public string Id { get; set; }
-        public string Name { get; set; }
         public List<Field> Fields { get; set; }
     }
 }

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/Controls/FieldReference.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/Controls/FieldReference.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
+{
+    public class FieldReference
+    {
+        public string Name { get; set; }
+    }
+}

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/Controls/LookupItem.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/Controls/LookupItem.cs
@@ -3,9 +3,8 @@
 
 namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 {
-    public class LookupItem
+    public class LookupItem : FieldReference
     {
-        public string Name { get; set; }
         public string Value { get; set; }
         public int Index { get; set; }
     }

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/Controls/MultiValueOptionSet.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/Controls/MultiValueOptionSet.cs
@@ -3,9 +3,8 @@
 
 namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 {
-    public class MultiValueOptionSet
+    public class MultiValueOptionSet : FieldReference
     {
-        public string Name { get; set; }
         public string[] Values { get; set; }
     }
 }

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/Controls/OptionSet.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/Controls/OptionSet.cs
@@ -6,9 +6,8 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
     /// <summary>
     /// Represents an Option Set in Dynamics 365.
     /// </summary>
-    public class OptionSet
+    public class OptionSet : FieldReference
     {
-        public string Name { get; set; }
         public string Value { get; set; }
     }
 }

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/Elements/Entity.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/Elements/Entity.cs
@@ -218,6 +218,11 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             return _client.GetValue(field);
         }
 
+        public string GetValue(FieldReference field)
+        {
+            return _client.GetValue(field);
+        }
+
         /// <summary>
         /// Gets the value of a picklist or status field.
         /// </summary>
@@ -372,6 +377,11 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         /// <param name="field">The field</param>
         /// <param name="value">The value</param>
         public void SetValue(string field, string value)
+        {
+            _client.SetValue(field, value);
+        }
+
+        public void SetValue(FieldReference field, string value)
         {
             _client.SetValue(field, value);
         }

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/Microsoft.Dynamics365.UIAutomation.Api.UCI.csproj
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/Microsoft.Dynamics365.UIAutomation.Api.UCI.csproj
@@ -55,6 +55,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Controls\FieldReference.cs" />
     <Compile Include="Controls\CompositeControl.cs" />
     <Compile Include="Controls\Field.cs" />
     <Compile Include="Controls\LookupItem.cs" />


### PR DESCRIPTION
…eanItem, etc)

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (updates to documentation, formatting, etc.)

### Description
<!--- Describe your changes -->
Created FieldReference class which is extended by each control class. This allows controls to be returned as and iterated over as a typed collection.

### Issues addressed
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Could not create and iterate over a collection of mixed-type controls.

### All submissions:

- [x] My code follows the code style of this project.
- [x] Do existing samples that are affected by this change still run?
- [ ] I have added samples for new functionality. 
- [x] I raise detailed error messages when possible.
- [x] My code does not rely on labels that have the option to be hidden.

### Which browsers was this tested on?
<!--- Should be tested on Chrome, Firefox, and IE. -->
- [x] Chrome
- [x] Firefox
- [x] IE
- [ ] Edge
