### PR TITLE
bug fixes

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/AppElementReference.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/AppElementReference.cs
@@ -332,7 +332,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             { "Entity_LookupFieldResultList", "//*[contains(@data-id, '[NAME].fieldControl-LookupResultsDropdown_[NAME]_tab')]" },
             { "Entity_LookupFieldResultListItem", "//*[contains(@data-id, '[NAME].fieldControl-LookupResultsDropdown_[NAME]_resultsContainer')]" },
             { "Entity_LookupFieldHoverExistingValue", "//*[contains(@data-id, '[NAME].fieldControl-LookupResultsDropdown_[NAME]_SelectedRecordList')]" },
-            { "Entity_TextFieldLookupFieldContainer", "//div[@role='tabpanel']/parent::*//*[contains(@data-id, '[NAME].fieldControl-Lookup_[NAME]')]" },
+            { "Entity_TextFieldLookupFieldContainer", "//div[@data-id='[NAME].fieldControl-Lookup_[NAME]']" },
             { "Entity_RecordSetNavigatorOpen", "//button[contains(@data-lp-id, 'recordset-navigator')]" },
             { "Entity_RecordSetNavigator", "//button[contains(@data-lp-id, 'recordset-navigator')]" },
             { "Entity_RecordSetNavList", "//ul[contains(@data-id, 'recordSetNaveList')]" },

--- a/Microsoft.Dynamics365.UIAutomation.Browser/Extensions/SeleniumExtensions.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Browser/Extensions/SeleniumExtensions.cs
@@ -588,8 +588,15 @@ namespace Microsoft.Dynamics365.UIAutomation.Browser
 
             try
             {
-                returnElement = wait.Until(d => d.FindElement(by));
-
+                var foundElements = wait.Until(d => d.FindElements(by));
+                if (foundElements != null && foundElements.Count > 1)
+                {
+                    returnElement = foundElements.FirstOrDefault(x => x.Displayed == true);
+                }
+                else
+                {
+                    returnElement = foundElements.FirstOrDefault();
+                }
                 success = true;
             }
             catch (NoSuchElementException)


### PR DESCRIPTION
### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (updates to documentation, formatting, etc.)

### Description
Latest version of EasyRepro introduced a new bug #702 while trying to fix #620 . The new bug is to do with Quick Create form not working for Lookup fields. The fix for this is to sort of undo the changes for the fix of bug #620 . 
This pull request also include a fix for bug #684 where the quick create form elements not interactable due to the page having 2 fields with the same data-id (1 from quick create and 1 from the main entity). This issue happened because the codes only look for the first element on the page using a given **data-id**. It would find the one on the main page for creating/editing this entity record instead of the one from Quick Create. To address this issue, we have to find all elements matching the given **data-id** and check for the one that is visible on the screen.

### Issues addressed
This would fix the issue with Lookup field on Quick Create form and not causing bug #620 to be recreated. 
The fix for bug #684 would make the Quick Create form works perfectly for that specific case and any other cases. 

### All submissions:

- [x] My code follows the code style of this project.
- [x] Do existing samples that are effected by this change still run?
- [ ] I have added samples for new functionality. 
- [ ] I raise detailed error messages when possible.
- [ ] My code does not rely on labels that have the option to be hidden.

### Which browsers was this tested on?
<!--- Should be tested on Chrome, Firefox, and IE. -->
- [x] Chrome
- [ ] Firefox
- [ ] IE
- [ ] Edge
