### PR TITLE
Create UCI header flyout for Get-SetHeaderValue

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/AppElementReference.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/AppElementReference.cs
@@ -129,6 +129,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             public static string EntityOptionsetStatusComboButton = "Entity_OptionsetStatusComboButton";
             public static string EntityOptionsetStatusComboList = "Entity_OptionsetStatusComboList";
             public static string EntityOptionsetStatusTextValue = "Entity_OptionsetStatusTextValue";
+            public static string HeaderFlyoutButton = "Entity_HeaderFlyoutButton";
 
         }
 
@@ -371,6 +372,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             { "Entity_OptionsetStatusComboButton", "//div[contains(@id, '[NAME].fieldControl-pickliststatus-comboBox_button')]"},
             { "Entity_OptionsetStatusComboList", "//ul[contains(@id, '[NAME].fieldControl-pickliststatus-comboBox_list')]"},
             { "Entity_OptionsetStatusTextValue", "//span[contains(@id, '[NAME].fieldControl-pickliststatus-comboBox_text-value')]"},
+            { "Entity_HeaderFlyoutButton","//button[contains(@id,'headerFieldsExpandButton')]" },
                         
             //CommandBar
             { "Cmd_Container"       , "//ul[contains(@data-lp-id,\"commandbar-Form\")]"},

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -2653,7 +2653,12 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 if (!driver.HasElement(By.XPath(AppElements.Xpath[AppReference.Entity.EntityHeader])))
                     throw new NotFoundException("Unable to find header on the form");
 
-                var flyoutButton = driver.ClickWhenAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton]));
+                bool expanded = bool.Parse(driver.FindElement(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton])).GetAttribute("aria-expanded"));
+
+                if (!expanded)
+                {
+                    var flyoutButton = driver.ClickWhenAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton]));
+                }
 
                 return GetValue(control);
             });
@@ -2666,7 +2671,12 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 if (!driver.HasElement(By.XPath(AppElements.Xpath[AppReference.Entity.EntityHeader])))
                     throw new NotFoundException("Unable to find header on the form");
 
-                var flyoutButton = driver.ClickWhenAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton]));
+                bool expanded = bool.Parse(driver.FindElement(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton])).GetAttribute("aria-expanded"));
+
+                if (!expanded)
+                {
+                    var flyoutButton = driver.ClickWhenAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton]));
+                }
 
                 return GetValue(controls);
             });
@@ -2679,7 +2689,12 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 if (!driver.HasElement(By.XPath(AppElements.Xpath[AppReference.Entity.EntityHeader])))
                     throw new NotFoundException("Unable to find header on the form");
 
-                var flyoutButton = driver.ClickWhenAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton]));
+                bool expanded = bool.Parse(driver.FindElement(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton])).GetAttribute("aria-expanded"));
+
+                if (!expanded)
+                {
+                    var flyoutButton = driver.ClickWhenAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton]));
+                }
 
                 return GetValue(control);
             });
@@ -2692,7 +2707,12 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 if (!driver.HasElement(By.XPath(AppElements.Xpath[AppReference.Entity.EntityHeader])))
                     throw new NotFoundException("Unable to find header on the form");
 
-                var flyoutButton = driver.ClickWhenAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton]));
+                bool expanded = bool.Parse(driver.FindElement(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton])).GetAttribute("aria-expanded"));
+
+                if (!expanded)
+                {
+                    var flyoutButton = driver.ClickWhenAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton]));
+                }
 
                 return GetValue(control);
             });
@@ -2705,7 +2725,12 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 if (!driver.HasElement(By.XPath(AppElements.Xpath[AppReference.Entity.EntityHeader])))
                     throw new NotFoundException("Unable to find header on the form");
 
-                var flyoutButton = driver.ClickWhenAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton]));
+                bool expanded = bool.Parse(driver.FindElement(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton])).GetAttribute("aria-expanded"));
+
+                if (!expanded)
+                {
+                    var flyoutButton = driver.ClickWhenAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton]));
+                }
 
                 return GetValue(control);
             });
@@ -2718,7 +2743,12 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 if (!driver.HasElement(By.XPath(AppElements.Xpath[AppReference.Entity.EntityHeader])))
                     throw new NotFoundException("Unable to find header on the form");
 
-                var flyoutButton = driver.ClickWhenAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton]));
+                bool expanded = bool.Parse(driver.FindElement(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton])).GetAttribute("aria-expanded"));
+
+                if (!expanded)
+                {
+                    var flyoutButton = driver.ClickWhenAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton]));
+                }
 
                 return GetValue(control);
             });
@@ -2750,7 +2780,12 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 if (!driver.HasElement(By.XPath(AppElements.Xpath[AppReference.Entity.EntityHeader])))
                     throw new NotFoundException("Unable to find header on the form");
 
-                var flyoutButton = driver.ClickWhenAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton]));
+                bool expanded = bool.Parse(driver.FindElement(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton])).GetAttribute("aria-expanded"));
+
+                if (!expanded)
+                {
+                    var flyoutButton = driver.ClickWhenAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton]));
+                }
 
                 SetValue(field, value);
 
@@ -2765,7 +2800,12 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 if (!driver.HasElement(By.XPath(AppElements.Xpath[AppReference.Entity.EntityHeader])))
                     throw new NotFoundException("Unable to find header on the form");
 
-                var flyoutButton = driver.ClickWhenAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton]));
+                bool expanded = bool.Parse(driver.FindElement(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton])).GetAttribute("aria-expanded"));
+
+                if (!expanded)
+                {
+                    var flyoutButton = driver.ClickWhenAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton]));
+                }
 
                 SetValue(control);
 
@@ -2780,7 +2820,12 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 if (!driver.HasElement(By.XPath(AppElements.Xpath[AppReference.Entity.EntityHeader])))
                     throw new NotFoundException("Unable to find header on the form");
 
-                var flyoutButton = driver.ClickWhenAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton]));
+                bool expanded = bool.Parse(driver.FindElement(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton])).GetAttribute("aria-expanded"));
+
+                if (!expanded)
+                {
+                    var flyoutButton = driver.ClickWhenAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton]));
+                }
 
                 SetValue(controls);
 
@@ -2795,7 +2840,12 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 if (!driver.HasElement(By.XPath(AppElements.Xpath[AppReference.Entity.EntityHeader])))
                     throw new NotFoundException("Unable to find header on the form");
 
-                var flyoutButton = driver.ClickWhenAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton]));
+                bool expanded = bool.Parse(driver.FindElement(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton])).GetAttribute("aria-expanded"));
+
+                if (!expanded)
+                {
+                    var flyoutButton = driver.ClickWhenAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton]));
+                }
 
                 SetValue(control);
 
@@ -2810,7 +2860,12 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 if (!driver.HasElement(By.XPath(AppElements.Xpath[AppReference.Entity.EntityHeader])))
                     throw new NotFoundException("Unable to find header on the form");
 
-                var flyoutButton = driver.ClickWhenAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton]));
+                bool expanded = bool.Parse(driver.FindElement(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton])).GetAttribute("aria-expanded"));
+
+                if (!expanded)
+                {
+                    var flyoutButton = driver.ClickWhenAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton]));
+                }
 
                 SetValue(control);
 
@@ -2825,7 +2880,12 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 if (!driver.HasElement(By.XPath(AppElements.Xpath[AppReference.Entity.EntityHeader])))
                     throw new NotFoundException("Unable to find header on the form");
 
-                var flyoutButton = driver.ClickWhenAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton]));
+                bool expanded = bool.Parse(driver.FindElement(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton])).GetAttribute("aria-expanded"));
+
+                if (!expanded)
+                {
+                    var flyoutButton = driver.ClickWhenAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton]));
+                }
 
                 SetValue(control);
 
@@ -2840,7 +2900,12 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 if (!driver.HasElement(By.XPath(AppElements.Xpath[AppReference.Entity.EntityHeader])))
                     throw new NotFoundException("Unable to find header on the form");
 
-                var flyoutButton = driver.ClickWhenAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton]));
+                bool expanded = bool.Parse(driver.FindElement(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton])).GetAttribute("aria-expanded"));
+
+                if (!expanded)
+                {
+                    var flyoutButton = driver.ClickWhenAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton]));
+                }
 
                 SetValue(field, date, format);
 

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -2653,6 +2653,8 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 if (!driver.HasElement(By.XPath(AppElements.Xpath[AppReference.Entity.EntityHeader])))
                     throw new NotFoundException("Unable to find header on the form");
 
+                var flyoutButton = driver.ClickWhenAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton]));
+
                 return GetValue(control);
             });
         }
@@ -2663,6 +2665,8 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             {
                 if (!driver.HasElement(By.XPath(AppElements.Xpath[AppReference.Entity.EntityHeader])))
                     throw new NotFoundException("Unable to find header on the form");
+
+                var flyoutButton = driver.ClickWhenAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton]));
 
                 return GetValue(controls);
             });
@@ -2675,6 +2679,8 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 if (!driver.HasElement(By.XPath(AppElements.Xpath[AppReference.Entity.EntityHeader])))
                     throw new NotFoundException("Unable to find header on the form");
 
+                var flyoutButton = driver.ClickWhenAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton]));
+
                 return GetValue(control);
             });
         }
@@ -2685,6 +2691,8 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             {
                 if (!driver.HasElement(By.XPath(AppElements.Xpath[AppReference.Entity.EntityHeader])))
                     throw new NotFoundException("Unable to find header on the form");
+
+                var flyoutButton = driver.ClickWhenAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton]));
 
                 return GetValue(control);
             });
@@ -2697,6 +2705,8 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 if (!driver.HasElement(By.XPath(AppElements.Xpath[AppReference.Entity.EntityHeader])))
                     throw new NotFoundException("Unable to find header on the form");
 
+                var flyoutButton = driver.ClickWhenAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton]));
+
                 return GetValue(control);
             });
         }
@@ -2707,6 +2717,8 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             {
                 if (!driver.HasElement(By.XPath(AppElements.Xpath[AppReference.Entity.EntityHeader])))
                     throw new NotFoundException("Unable to find header on the form");
+
+                var flyoutButton = driver.ClickWhenAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton]));
 
                 return GetValue(control);
             });
@@ -2738,6 +2750,8 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 if (!driver.HasElement(By.XPath(AppElements.Xpath[AppReference.Entity.EntityHeader])))
                     throw new NotFoundException("Unable to find header on the form");
 
+                var flyoutButton = driver.ClickWhenAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton]));
+
                 SetValue(field, value);
 
                 return true;
@@ -2750,6 +2764,8 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             {
                 if (!driver.HasElement(By.XPath(AppElements.Xpath[AppReference.Entity.EntityHeader])))
                     throw new NotFoundException("Unable to find header on the form");
+
+                var flyoutButton = driver.ClickWhenAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton]));
 
                 SetValue(control);
 
@@ -2764,6 +2780,8 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 if (!driver.HasElement(By.XPath(AppElements.Xpath[AppReference.Entity.EntityHeader])))
                     throw new NotFoundException("Unable to find header on the form");
 
+                var flyoutButton = driver.ClickWhenAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton]));
+
                 SetValue(controls);
 
                 return true;
@@ -2776,6 +2794,8 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             {
                 if (!driver.HasElement(By.XPath(AppElements.Xpath[AppReference.Entity.EntityHeader])))
                     throw new NotFoundException("Unable to find header on the form");
+
+                var flyoutButton = driver.ClickWhenAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton]));
 
                 SetValue(control);
 
@@ -2790,6 +2810,8 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 if (!driver.HasElement(By.XPath(AppElements.Xpath[AppReference.Entity.EntityHeader])))
                     throw new NotFoundException("Unable to find header on the form");
 
+                var flyoutButton = driver.ClickWhenAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton]));
+
                 SetValue(control);
 
                 return true;
@@ -2803,6 +2825,8 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 if (!driver.HasElement(By.XPath(AppElements.Xpath[AppReference.Entity.EntityHeader])))
                     throw new NotFoundException("Unable to find header on the form");
 
+                var flyoutButton = driver.ClickWhenAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton]));
+
                 SetValue(control);
 
                 return true;
@@ -2815,6 +2839,8 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             {
                 if (!driver.HasElement(By.XPath(AppElements.Xpath[AppReference.Entity.EntityHeader])))
                     throw new NotFoundException("Unable to find header on the form");
+
+                var flyoutButton = driver.ClickWhenAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton]));
 
                 SetValue(field, date, format);
 

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -2653,12 +2653,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 if (!driver.HasElement(By.XPath(AppElements.Xpath[AppReference.Entity.EntityHeader])))
                     throw new NotFoundException("Unable to find header on the form");
 
-                bool expanded = bool.Parse(driver.FindElement(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton])).GetAttribute("aria-expanded"));
-
-                if (!expanded)
-                {
-                    var flyoutButton = driver.ClickWhenAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton]));
-                }
+                ExpandHeader(driver);
 
                 return GetValue(control);
             });
@@ -2671,12 +2666,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 if (!driver.HasElement(By.XPath(AppElements.Xpath[AppReference.Entity.EntityHeader])))
                     throw new NotFoundException("Unable to find header on the form");
 
-                bool expanded = bool.Parse(driver.FindElement(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton])).GetAttribute("aria-expanded"));
-
-                if (!expanded)
-                {
-                    var flyoutButton = driver.ClickWhenAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton]));
-                }
+                ExpandHeader(driver);
 
                 return GetValue(controls);
             });
@@ -2689,12 +2679,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 if (!driver.HasElement(By.XPath(AppElements.Xpath[AppReference.Entity.EntityHeader])))
                     throw new NotFoundException("Unable to find header on the form");
 
-                bool expanded = bool.Parse(driver.FindElement(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton])).GetAttribute("aria-expanded"));
-
-                if (!expanded)
-                {
-                    var flyoutButton = driver.ClickWhenAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton]));
-                }
+                ExpandHeader(driver);
 
                 return GetValue(control);
             });
@@ -2707,12 +2692,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 if (!driver.HasElement(By.XPath(AppElements.Xpath[AppReference.Entity.EntityHeader])))
                     throw new NotFoundException("Unable to find header on the form");
 
-                bool expanded = bool.Parse(driver.FindElement(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton])).GetAttribute("aria-expanded"));
-
-                if (!expanded)
-                {
-                    var flyoutButton = driver.ClickWhenAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton]));
-                }
+                ExpandHeader(driver);
 
                 return GetValue(control);
             });
@@ -2725,12 +2705,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 if (!driver.HasElement(By.XPath(AppElements.Xpath[AppReference.Entity.EntityHeader])))
                     throw new NotFoundException("Unable to find header on the form");
 
-                bool expanded = bool.Parse(driver.FindElement(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton])).GetAttribute("aria-expanded"));
-
-                if (!expanded)
-                {
-                    var flyoutButton = driver.ClickWhenAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton]));
-                }
+                ExpandHeader(driver);
 
                 return GetValue(control);
             });
@@ -2743,12 +2718,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 if (!driver.HasElement(By.XPath(AppElements.Xpath[AppReference.Entity.EntityHeader])))
                     throw new NotFoundException("Unable to find header on the form");
 
-                bool expanded = bool.Parse(driver.FindElement(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton])).GetAttribute("aria-expanded"));
-
-                if (!expanded)
-                {
-                    var flyoutButton = driver.ClickWhenAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton]));
-                }
+                ExpandHeader(driver);
 
                 return GetValue(control);
             });
@@ -2780,12 +2750,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 if (!driver.HasElement(By.XPath(AppElements.Xpath[AppReference.Entity.EntityHeader])))
                     throw new NotFoundException("Unable to find header on the form");
 
-                bool expanded = bool.Parse(driver.FindElement(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton])).GetAttribute("aria-expanded"));
-
-                if (!expanded)
-                {
-                    var flyoutButton = driver.ClickWhenAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton]));
-                }
+                ExpandHeader(driver);
 
                 SetValue(field, value);
 
@@ -2800,12 +2765,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 if (!driver.HasElement(By.XPath(AppElements.Xpath[AppReference.Entity.EntityHeader])))
                     throw new NotFoundException("Unable to find header on the form");
 
-                bool expanded = bool.Parse(driver.FindElement(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton])).GetAttribute("aria-expanded"));
-
-                if (!expanded)
-                {
-                    var flyoutButton = driver.ClickWhenAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton]));
-                }
+                ExpandHeader(driver);
 
                 SetValue(control);
 
@@ -2820,12 +2780,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 if (!driver.HasElement(By.XPath(AppElements.Xpath[AppReference.Entity.EntityHeader])))
                     throw new NotFoundException("Unable to find header on the form");
 
-                bool expanded = bool.Parse(driver.FindElement(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton])).GetAttribute("aria-expanded"));
-
-                if (!expanded)
-                {
-                    var flyoutButton = driver.ClickWhenAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton]));
-                }
+                ExpandHeader(driver);
 
                 SetValue(controls);
 
@@ -2840,12 +2795,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 if (!driver.HasElement(By.XPath(AppElements.Xpath[AppReference.Entity.EntityHeader])))
                     throw new NotFoundException("Unable to find header on the form");
 
-                bool expanded = bool.Parse(driver.FindElement(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton])).GetAttribute("aria-expanded"));
-
-                if (!expanded)
-                {
-                    var flyoutButton = driver.ClickWhenAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton]));
-                }
+                ExpandHeader(driver);
 
                 SetValue(control);
 
@@ -2860,12 +2810,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 if (!driver.HasElement(By.XPath(AppElements.Xpath[AppReference.Entity.EntityHeader])))
                     throw new NotFoundException("Unable to find header on the form");
 
-                bool expanded = bool.Parse(driver.FindElement(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton])).GetAttribute("aria-expanded"));
-
-                if (!expanded)
-                {
-                    var flyoutButton = driver.ClickWhenAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton]));
-                }
+                ExpandHeader(driver);
 
                 SetValue(control);
 
@@ -2880,12 +2825,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 if (!driver.HasElement(By.XPath(AppElements.Xpath[AppReference.Entity.EntityHeader])))
                     throw new NotFoundException("Unable to find header on the form");
 
-                bool expanded = bool.Parse(driver.FindElement(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton])).GetAttribute("aria-expanded"));
-
-                if (!expanded)
-                {
-                    var flyoutButton = driver.ClickWhenAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton]));
-                }
+                ExpandHeader(driver);
 
                 SetValue(control);
 
@@ -2900,12 +2840,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 if (!driver.HasElement(By.XPath(AppElements.Xpath[AppReference.Entity.EntityHeader])))
                     throw new NotFoundException("Unable to find header on the form");
 
-                bool expanded = bool.Parse(driver.FindElement(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton])).GetAttribute("aria-expanded"));
-
-                if (!expanded)
-                {
-                    var flyoutButton = driver.ClickWhenAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton]));
-                }
+                ExpandHeader(driver);
 
                 SetValue(field, date, format);
 
@@ -3074,6 +3009,17 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 return true;
             });
         }
+
+        internal void ExpandHeader(IWebDriver driver)
+        {
+            bool expanded = bool.Parse(driver.FindElement(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton])).GetAttribute("aria-expanded"));
+
+            if (!expanded)
+            {
+                driver.ClickWhenAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderFlyoutButton]));
+            }
+        }
+
 
         #endregion
 


### PR DESCRIPTION
### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (updates to documentation, formatting, etc.)

### Description
Create AppElementReference for the header flyout on entity forms.
  
### Issues addressed
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Without clicking on the header flyout button, you could not use the GetHeaderValue or SetHeaderValue API.  Open issue is https://github.com/microsoft/EasyRepro/issues/717


### All submissions:

- [X] My code follows the code style of this project.
- [X] Do existing samples that are effected by this change still run?  Test was: UCITestOpenCaseRetrieveHeaderValues and UCITestUpdateActiveCaseSetHeaderValues
- [ ] I have added samples for new functionality. 
- [ ] I raise detailed error messages when possible.
- [X] My code does not rely on labels that have the option to be hidden.

### Which browsers was this tested on?
<!--- Should be tested on Chrome, Firefox, and IE. -->
- [X] Chrome
- [ ] Firefox
- [ ] IE
- [ ] Edge
