### PR TITLE
Add double click option for opening a grid row. Prevents opening a Lo…

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/AppElementReference.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/AppElementReference.cs
@@ -113,6 +113,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             public static string SubGridRows = "Entity_SubGridRows";
             public static string SubGridHeaders = "Entity_SubGridHeaders";
             public static string SubGridRecordCheckbox = "Entity_SubGridRecordCheckbox";
+            public static string SubGridAddButton = "Entity_SubGridAddButton";
             public static string FieldLookupButton = "Entity_FieldLookupButton";
             public static string SearchButtonIcon = "Entity_SearchButtonIcon";
             public static string EntityHeader = "Entity_Header";
@@ -357,6 +358,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             { "Entity_SubGridRows",".//div[contains(@class,'wj-row')]"},
             { "Entity_SubGridHeaders",".//div[contains(@class,'grid-header-text')]"},
             { "Entity_SubGridRecordCheckbox","//div[contains(@data-id,'cell-[INDEX]-1') and contains(@data-lp-id,'[NAME]')]"},
+            { "Entity_SubGridAddButton", "//button[contains(@data-id,'[NAME].AddNewStandard')]/parent::li/parent::ul[contains(@data-lp-id, 'commandbar-SubGridStandard:[NAME]')]" },
             { "Entity_FieldLookupButton","//button[contains(@data-id,'[NAME]_search')]" },
             { "Entity_SearchButtonIcon", "//span[contains(@data-id,'microsoftIcon_searchButton')]" },
             { "Entity_Header", "//div[contains(@data-id,'form-header')]"},

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/Elements/Entity.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/Elements/Entity.cs
@@ -296,6 +296,11 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             _client.OpenSubGridRecord(subgridName, index);
         }
 
+        public void AddSubgridItem(string subgridName)
+        {
+            _client.ClickSubgridAddButton(subgridName);
+        }
+
         /// <summary>
         /// Saves the entity
         /// </summary>

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -1257,8 +1257,16 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                     {
                         if (currentindex == index)
                         {
-                            var tag = checkRecord ? "div" : "a";
-                            row.FindElement(By.TagName(tag)).Click();
+                            var tag = "div";
+                            if (checkRecord)
+                            {
+                                row.FindElement(By.TagName(tag)).Click();
+                            }
+                            else
+                            {
+                                driver.DoubleClick(row.FindElement(By.TagName(tag)));
+                            }
+
                             break;
                         }
 

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -1635,6 +1635,22 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         }
         #endregion
 
+        #region Subgrid
+
+        public BrowserCommandResult<bool> ClickSubgridAddButton(string subgridName, int thinkTime = Constants.DefaultThinkTime)
+        {
+            Browser.ThinkTime(thinkTime);
+
+            return this.Execute(GetOptions($"Click add button of subgrid: {subgridName}"), driver =>
+            {
+                driver.FindElement(By.XPath(AppElements.Xpath[AppReference.Entity.SubGridAddButton].Replace("[NAME]", subgridName)))?.Click();
+
+                return true;
+            });
+        }
+
+        #endregion
+
         #region Entity
 
         internal BrowserCommandResult<bool> CancelQuickCreate(int thinkTime = Constants.DefaultThinkTime)


### PR DESCRIPTION
…okup field instead.

### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (updates to documentation, formatting, etc.)

### Description
<!--- Describe your changes -->
Changed the code to always look for a div tag, and if selecting a record is called for, checking the box - otherwise, double click the row to open it.

### Issues addressed
<!--- Why is this change required? What problem does it solve? -->
Open Record method was clicking on a Lookup link and opening the linked (parent) record rather than opening the record represented by the grid row.

<!--- If it fixes an open issue, please link to the issue here. -->
Fixes: #655 

### All submissions:

- [X] My code follows the code style of this project.
- [X] Do existing samples that are effected by this change still run?
- [x] I have added samples for new functionality. 
- [x] I raise detailed error messages when possible.
- [x] My code does not rely on labels that have the option to be hidden.

### Which browsers was this tested on?
<!--- Should be tested on Chrome, Firefox, and IE. -->
- [X] Chrome
- [ ] Firefox
- [ ] IE
- [ ] Edge
