### PR TITLE
Fix Set/Get DateTime Value in Form Header

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/AppElementReference.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/AppElementReference.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             public static string RecordSetNavList = "Entity_RecordSetNavList";
             public static string RecordSetNavCollapseIcon = "Entity_RecordSetNavCollapseIcon";
             public static string RecordSetNavCollapseIconParent = "Entity_RecordSetNavCollapseIconParent";
-            public static string FieldControlDateTimeInput = "Entity_FieldControlDateTimeInput";
+            public static string FieldControlDateTimeContainer = "Entity_FieldControlDateTimeContainer";
             public static string FieldControlDateTimeInputUCI     = "Entity_FieldControlDateTimeInputUCI";
             public static string FieldControlDateTimeTimeInputUCI = "Entity_FieldControlDateTimeTimeInputUCI";
             public static string Delete = "Entity_Delete";
@@ -140,6 +140,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 public static string LookupFieldContainer = "Entity_Header_LookupFieldContainer";
                 public static string TextFieldContainer = "Entity_Header_TextFieldContainer";
                 public static string OptionSetFieldContainer = "Entity_Header_OptionSetFieldContainer";
+                public static string DateTimeFieldContainer = "Entity_Header_DateTimeFieldContainer";
             }
         }
     
@@ -355,10 +356,10 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             { "Entity_MoreTabs", ".//button[@data-id='more_button']" },
             { "Entity_MoreTabsMenu", "//div[@id='__flyoutRootNode']" },
             { "Entity_SubTab", "//div[@id=\"__flyoutRootNode\"]//span[text()=\"{0}\"]" },
-            { "Entity_FieldControlDateTimeInput","//input[contains(@id,'[FIELD].fieldControl-date-time-input')]" },
-            { "Entity_FieldControlDateTimeInputUCI","//input[contains(@data-id,'[FIELD].fieldControl-date-time-input')]" },
-            { "Entity_FieldControlDateTimeTimeInputUCI","//div[contains(@data-id,'[FIELD].fieldControl._timecontrol-datetime-container')]/div/div/input" },
-            { "Entity_LookupResultsDropdown", "//*[contains(@data-id, \'[NAME].fieldControl-LookupResultsDropdown_[NAME]_tab')]" },
+            { "Entity_FieldControlDateTimeContainer","//div[@data-id='[NAME]-FieldSectionItemContainer']" },
+            { "Entity_FieldControlDateTimeInputUCI",".//input[@data-id='[FIELD].fieldControl-date-time-input']" },
+            { "Entity_FieldControlDateTimeTimeInputUCI",".//div[contains(@data-id,'[FIELD].fieldControl._timecontrol-datetime-container')]/div/div/input" },
+            { "Entity_LookupResultsDropdown", "//*[contains(@data-id, '[NAME].fieldControl-LookupResultsDropdown_[NAME]_tab')]" },
             { "Entity_Footer", "//div[contains(@id,'footerWrapper')]" },
             { "Entity_SubGridTitle", "//div[contains(text(), '[NAME]')]"},
             { "Entity_SubGridContents", "//div[contains(text(), '[NAME]')]/parent::div/parent::div/parent::div"},
@@ -392,6 +393,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             { "Entity_Header_LookupFieldContainer", "//div[@data-id='header_[NAME].fieldControl-Lookup_[NAME]']" },
             { "Entity_Header_TextFieldContainer", "//div[@data-id='header_[NAME].fieldControl-text-box-container']" },
             { "Entity_Header_OptionSetFieldContainer", "//div[@data-id='header_[NAME].fieldControl-option-set-container']" },
+            { "Entity_Header_DateTimeFieldContainer","//div[@data-id='header_[NAME]-FieldSectionItemContainer']" },
                         
             //CommandBar
             { "Cmd_Container"       , "//ul[contains(@data-lp-id,\"commandbar-Form\")]"},

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -155,7 +155,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 if (redirectAction != null)
                 {
                     //Wait for redirect to occur.
-                    Thread.Sleep(3000);
+                    ThinkTime(3000);
 
                     redirectAction.Invoke(new LoginRedirectEventArgs(username, password, driver));
                     return LoginResult.Redirect;
@@ -213,7 +213,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             input.Submit();
         }
 
-        private static void EnterOneTimeCode(IWebDriver driver, SecureString mfaSecrectKey)
+        private void EnterOneTimeCode(IWebDriver driver, SecureString mfaSecrectKey)
         {
             int attempts = 0;
             while (true)
@@ -221,24 +221,27 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 try
                 {
                     IWebElement input = GetOtcInput(driver);
-                    var oneTimeCode = GenerateOneTimeCode(mfaSecrectKey);
-                    input.SendKeys(oneTimeCode);
-                    input.Submit();
-                    return;
+                    if (input != null)
+                    {
+                        var oneTimeCode = GenerateOneTimeCode(mfaSecrectKey);
+                        input.SendKeys(oneTimeCode);
+                        input.Submit();
+                        return;
+                    }
                 }
                 catch (Exception e)
                 {
-                    Trace.TraceWarning($"An Error ocur entering OTC. Exception: {e}");
+                    Trace.TraceInformation($"An Error ocur entering OTC. Attempt {attempts} of {Constants.DefaultRetryAttempts}. Exception: {e}");
                     if (attempts >= Constants.DefaultRetryAttempts)
                         throw;
-                    Thread.Sleep(Constants.DefaultRetryDelay);
-                    attempts++;
                 }
+                attempts++;
+                ThinkTime(Constants.DefaultRetryDelay);
             }
         }
 
         private static IWebElement GetOtcInput(IWebDriver driver)
-            => driver.FindElement(By.XPath(Elements.Xpath[Reference.Login.OneTimeCode]));
+            => driver.WaitUntilAvailable(By.XPath(Elements.Xpath[Reference.Login.OneTimeCode]), TimeSpan.FromSeconds(2));
 
         private static void ClickStaySignedIn(IWebDriver driver)
         {
@@ -308,7 +311,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 
             //This method expects single sign-on
 
-            Browser.ThinkTime(5000);
+            ThinkTime(5000);
 
             driver.WaitUntilVisible(By.XPath("//div[@id=\"mfaGreetingDescription\"]"));
 
@@ -330,7 +333,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 
         internal BrowserCommandResult<bool> OpenApp(string appName, int thinkTime = Constants.DefaultThinkTime)
         {
-            Browser.ThinkTime(thinkTime);
+            ThinkTime(thinkTime);
 
             return Execute(GetOptions($"Open App {appName}"), driver =>
             {
@@ -404,7 +407,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 
         internal BrowserCommandResult<bool> OpenGroupSubArea(string group, string subarea, int thinkTime = Constants.DefaultThinkTime)
         {
-            this.Browser.ThinkTime(thinkTime);
+            ThinkTime(thinkTime);
 
             return this.Execute(GetOptions("Open Group Sub Area"), driver =>
             {
@@ -727,7 +730,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         /// <example>xrmBrowser.Navigation.OpenGuidedHelp();</example>
         public BrowserCommandResult<bool> OpenGuidedHelp(int thinkTime = Constants.DefaultThinkTime)
         {
-            Browser.ThinkTime(thinkTime);
+            ThinkTime(thinkTime);
 
             return this.Execute(GetOptions($"Open Guided Help"), driver =>
             {
@@ -744,7 +747,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         /// <example>xrmBrowser.Navigation.OpenAdminPortal();</example>
         internal BrowserCommandResult<bool> OpenAdminPortal(int thinkTime = Constants.DefaultThinkTime)
         {
-            this.Browser.ThinkTime(thinkTime);
+            ThinkTime(thinkTime);
             return this.Execute(GetOptions("Open Admin Portal"), driver =>
             {
                 driver.WaitUntilVisible(By.XPath(AppElements.Xpath[AppReference.Application.Shell]));
@@ -761,7 +764,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         /// <example>xrmBrowser.Navigation.OpenGlobalSearch();</example>
         internal BrowserCommandResult<bool> OpenGlobalSearch(int thinkTime = Constants.DefaultThinkTime)
         {
-            Browser.ThinkTime(thinkTime);
+            ThinkTime(thinkTime);
 
             return this.Execute(GetOptions($"Open Global Search"), driver =>
             {
@@ -776,7 +779,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 
         internal BrowserCommandResult<bool> ClickQuickLaunchButton(string toolTip, int thinkTime = Constants.DefaultThinkTime)
         {
-            Browser.ThinkTime(thinkTime);
+            ThinkTime(thinkTime);
 
             return this.Execute(GetOptions($"Quick Launch: {toolTip}"), driver =>
             {
@@ -793,7 +796,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 
         internal BrowserCommandResult<bool> QuickCreate(string entityName, int thinkTime = Constants.DefaultThinkTime)
         {
-            Browser.ThinkTime(thinkTime);
+            ThinkTime(thinkTime);
 
             return this.Execute(GetOptions($"Quick Create: {entityName}"), driver =>
             {
@@ -1008,7 +1011,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             //Check for Dialog and figure out which type it is and return the dialog type.
 
             //Introduce think time to avoid timing issues on save dialog
-            Browser.ThinkTime(1000);
+            ThinkTime(1000);
 
             return this.Execute(GetOptions($"Validate Save"), driver =>
             {
@@ -1090,7 +1093,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 
         internal BrowserCommandResult<bool> ClickCommand(string name, string subname = "", bool moreCommands = false, int thinkTime = Constants.DefaultThinkTime)
         {
-            this.Browser.ThinkTime(thinkTime);
+            ThinkTime(thinkTime);
 
             return this.Execute(GetOptions($"Click Command"), driver =>
             {
@@ -1167,7 +1170,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         /// <example>xrmBrowser.Related.ClickCommand("ADD NEW CASE");</example>
         internal BrowserCommandResult<List<string>> GetCommandValues(bool includeMoreCommandsValues = false, int thinkTime = Constants.DefaultThinkTime)
         {
-            Browser.ThinkTime(thinkTime);
+            ThinkTime(thinkTime);
 
             return this.Execute(GetOptions("Get CommandBar Command Count"), driver =>
             {
@@ -1261,7 +1264,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 
         public BrowserCommandResult<Dictionary<string, string>> OpenViewPicker(int thinkTime = Constants.DefaultThinkTime)
         {
-            Browser.ThinkTime(thinkTime);
+            ThinkTime(thinkTime);
 
             return this.Execute(GetOptions("Open View Picker"), driver =>
             {
@@ -1287,7 +1290,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 
         internal BrowserCommandResult<bool> SwitchView(string viewName, int thinkTime = Constants.DefaultThinkTime)
         {
-            this.Browser.ThinkTime(thinkTime);
+            ThinkTime(thinkTime);
 
             return this.Execute(GetOptions($"Switch View"), driver =>
             {
@@ -1307,7 +1310,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 
         internal BrowserCommandResult<bool> OpenRecord(int index, int thinkTime = Constants.DefaultThinkTime, bool checkRecord = false)
         {
-            this.Browser.ThinkTime(thinkTime);
+            ThinkTime(thinkTime);
 
             return Execute(GetOptions("Open Grid Record"), driver =>
             {
@@ -1337,7 +1340,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 
         internal BrowserCommandResult<bool> Search(string searchCriteria, bool clearByDefault = true, int thinkTime = Constants.DefaultThinkTime)
         {
-            this.Browser.ThinkTime(thinkTime);
+            ThinkTime(thinkTime);
 
             return this.Execute(GetOptions($"Search"), driver =>
             {
@@ -1359,7 +1362,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 
         internal BrowserCommandResult<bool> ClearSearch(int thinkTime = Constants.DefaultThinkTime)
         {
-            this.Browser.ThinkTime(thinkTime);
+            ThinkTime(thinkTime);
 
             return this.Execute(GetOptions($"Clear Search"), driver =>
             {
@@ -1373,7 +1376,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 
         internal BrowserCommandResult<List<GridItem>> GetGridItems(int thinkTime = Constants.DefaultThinkTime)
         {
-            Browser.ThinkTime(thinkTime);
+            ThinkTime(thinkTime);
 
             return this.Execute(GetOptions("Get Grid Items"), driver =>
             {
@@ -1435,7 +1438,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 
         internal BrowserCommandResult<bool> NextPage(int thinkTime = Constants.DefaultThinkTime)
         {
-            this.Browser.ThinkTime(thinkTime);
+            ThinkTime(thinkTime);
 
             return this.Execute(GetOptions($"Next Page"), driver =>
             {
@@ -1449,7 +1452,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 
         internal BrowserCommandResult<bool> PreviousPage(int thinkTime = Constants.DefaultThinkTime)
         {
-            this.Browser.ThinkTime(thinkTime);
+            ThinkTime(thinkTime);
 
             return this.Execute(GetOptions($"Previous Page"), driver =>
             {
@@ -1463,7 +1466,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 
         internal BrowserCommandResult<bool> FirstPage(int thinkTime = Constants.DefaultThinkTime)
         {
-            this.Browser.ThinkTime(thinkTime);
+            ThinkTime(thinkTime);
 
             return this.Execute(GetOptions($"First Page"), driver =>
             {
@@ -1477,7 +1480,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 
         internal BrowserCommandResult<bool> SelectAll(int thinkTime = Constants.DefaultThinkTime)
         {
-            this.Browser.ThinkTime(thinkTime);
+            ThinkTime(thinkTime);
 
             return this.Execute(GetOptions($"Select All"), driver =>
             {
@@ -1491,7 +1494,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 
         public BrowserCommandResult<bool> ShowChart(int thinkTime = Constants.DefaultThinkTime)
         {
-            Browser.ThinkTime(thinkTime);
+            ThinkTime(thinkTime);
 
             return this.Execute(GetOptions("Show Chart"), driver =>
             {
@@ -1512,7 +1515,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 
         public BrowserCommandResult<bool> HideChart(int thinkTime = Constants.DefaultThinkTime)
         {
-            Browser.ThinkTime(thinkTime);
+            ThinkTime(thinkTime);
 
             return this.Execute(GetOptions("Hide Chart"), driver =>
             {
@@ -1533,7 +1536,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 
         public BrowserCommandResult<bool> FilterByLetter(char filter, int thinkTime = Constants.DefaultThinkTime)
         {
-            Browser.ThinkTime(thinkTime);
+            ThinkTime(thinkTime);
 
             if (!Char.IsLetter(filter) && filter != '#')
                 throw new InvalidOperationException("Filter criteria is not valid.");
@@ -1560,7 +1563,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 
         public BrowserCommandResult<bool> FilterByAll(int thinkTime = Constants.DefaultThinkTime)
         {
-            Browser.ThinkTime(thinkTime);
+            ThinkTime(thinkTime);
 
             return this.Execute(GetOptions("Filter by All Records"), driver =>
             {
@@ -1584,7 +1587,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 
         public BrowserCommandResult<bool> SelectRecord(int index, int thinkTime = Constants.DefaultThinkTime)
         {
-            Browser.ThinkTime(thinkTime);
+            ThinkTime(thinkTime);
 
             return this.Execute(GetOptions("Select Grid Record"), driver =>
             {
@@ -1601,12 +1604,12 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 
         public BrowserCommandResult<bool> SwitchChart(string chartName, int thinkTime = Constants.DefaultThinkTime)
         {
-            Browser.ThinkTime(thinkTime);
+            ThinkTime(thinkTime);
 
             if (!Browser.Driver.IsVisible(By.XPath(AppElements.Xpath[AppReference.Grid.ChartSelector])))
                 ShowChart();
 
-            Browser.ThinkTime(1000);
+            ThinkTime(1000);
 
             return this.Execute(GetOptions("Switch Chart"), driver =>
             {
@@ -1622,7 +1625,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 
         public BrowserCommandResult<bool> Sort(string columnName, int thinkTime = Constants.DefaultThinkTime)
         {
-            Browser.ThinkTime(thinkTime);
+            ThinkTime(thinkTime);
 
             return this.Execute(GetOptions($"Sort by {columnName}"), driver =>
             {
@@ -1649,7 +1652,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         /// <param name="thinkTime">Used to simulate a wait time between human interactions. The Default is 2 seconds.</param>
         public BrowserCommandResult<bool> OpenGridRow(int index, int thinkTime = Constants.DefaultThinkTime)
         {
-            Browser.ThinkTime(thinkTime);
+            ThinkTime(thinkTime);
 
             return this.Execute(GetOptions("Open Grid Item"), driver =>
             {
@@ -1704,7 +1707,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 
         public BrowserCommandResult<bool> ClickSubgridAddButton(string subgridName, int thinkTime = Constants.DefaultThinkTime)
         {
-            Browser.ThinkTime(thinkTime);
+            ThinkTime(thinkTime);
 
             return this.Execute(GetOptions($"Click add button of subgrid: {subgridName}"), driver =>
             {
@@ -1720,7 +1723,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 
         internal BrowserCommandResult<bool> CancelQuickCreate(int thinkTime = Constants.DefaultThinkTime)
         {
-            this.Browser.ThinkTime(thinkTime);
+            ThinkTime(thinkTime);
 
             return this.Execute(GetOptions($"Cancel Quick Create"), driver =>
             {
@@ -1742,7 +1745,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         /// <param name="thinkTime">The think time</param>
         internal BrowserCommandResult<bool> OpenEntity(string entityName, Guid id, int thinkTime = Constants.DefaultThinkTime)
         {
-            this.Browser.ThinkTime(thinkTime);
+            ThinkTime(thinkTime);
 
             return this.Execute(GetOptions($"Open: {entityName} {id}"), driver =>
             {
@@ -1777,7 +1780,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         /// <param name="thinkTime"></param>
         internal BrowserCommandResult<bool> Save(int thinkTime = Constants.DefaultThinkTime)
         {
-            this.Browser.ThinkTime(thinkTime);
+            ThinkTime(thinkTime);
 
             return this.Execute(GetOptions($"Save"), driver =>
             {
@@ -1792,7 +1795,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 
         internal BrowserCommandResult<bool> SaveQuickCreate(int thinkTime = Constants.DefaultThinkTime)
         {
-            this.Browser.ThinkTime(thinkTime);
+            ThinkTime(thinkTime);
 
             return this.Execute(GetOptions($"SaveQuickCreate"), driver =>
             {
@@ -1815,7 +1818,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         /// <example>xrmBrowser.Entity.OpenRecordSetNavigator();</example>
         public BrowserCommandResult<bool> OpenRecordSetNavigator(int index = 0, int thinkTime = Constants.DefaultThinkTime)
         {
-            Browser.ThinkTime(thinkTime);
+            ThinkTime(thinkTime);
 
             return this.Execute(GetOptions("Open Record Set Navigator"), driver =>
             {
@@ -1849,7 +1852,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         /// <example>xrmApp.Entity.CloseRecordSetNavigator();</example>
         public BrowserCommandResult<bool> CloseRecordSetNavigator(int thinkTime = Constants.DefaultThinkTime)
         {
-            Browser.ThinkTime(thinkTime);
+            ThinkTime(thinkTime);
 
             return this.Execute(GetOptions("Close Record Set Navigator"), driver =>
             {
@@ -1893,7 +1896,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 
                 // Needed to transfer focus out of special fields (email or phone)
                 var label = fieldContainer.ClickIfVisible(By.TagName("label"));
-                if(label == null)
+                if (label == null)
                     driver.ClearFocus();
 
                 return true;
@@ -2181,20 +2184,20 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             => Execute(GetOptions($"Set Date/Time Value: {control.Name}"),
                 driver => TrySetValue(driver, container: driver, control: control));
 
-        private static bool TrySetValue(IWebDriver driver, ISearchContext container, DateTimeControl control)
+        private bool TrySetValue(IWebDriver driver, ISearchContext container, DateTimeControl control)
         {
             TrySetDateValue(driver, container, control);
             TrySetTime(driver, container, control);
-            
-            if(container is IWebElement parent)
+
+            if (container is IWebElement parent)
                 parent.Click(true);
-            else 
+            else
                 driver.ClearFocus();
 
             return true;
         }
 
-        private static void TrySetDateValue(IWebDriver driver, ISearchContext container, DateTimeControl control)
+        private void TrySetDateValue(IWebDriver driver, ISearchContext container, DateTimeControl control)
         {
             string controlName = control.Name;
             var xpathToInput = By.XPath(AppElements.Xpath[AppReference.Entity.FieldControlDateTimeInputUCI].Replace("[FIELD]", controlName));
@@ -2202,7 +2205,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             TrySetDateValue(driver, dateField, control.DateAsString);
         }
 
-        private static void TrySetDateValue(IWebDriver driver, IWebElement dateField, string date)
+        private void TrySetDateValue(IWebDriver driver, IWebElement dateField, string date)
         {
             var strExpanded = dateField.GetAttribute("aria-expanded");
             bool success = bool.TryParse(strExpanded, out var isCalendarExpanded);
@@ -2211,13 +2214,23 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 
             driver.RepeatUntil(() =>
                 {
-                    driver.DoubleClick(dateField);
-                    dateField.SendKeys(date ?? Keys.Backspace);
+                    ClearFieldValue(dateField);
+                    if(date!= null)
+                        dateField.SendKeys(date);
                 },
                 d => dateField.GetAttribute("value").IsValueEqualsTo(date),
-                new TimeSpan(0, 0, 9), 3,
+                TimeSpan.FromSeconds(9), 3,
                 failureCallback: () => throw new InvalidOperationException($"Timeout after 10 seconds. Expected: {date}. Actual: {dateField.GetAttribute("value")}")
             );
+        }
+        private void ClearFieldValue(IWebElement field)
+        {
+            if (field.GetAttribute("value").Length > 0)
+            {
+                field.SendKeys(Keys.Control + "a");
+                field.SendKeys(Keys.Backspace);
+            }
+            ThinkTime(500);
         }
 
         private static void TrySetTime(IWebDriver driver, ISearchContext container, DateTimeControl control)
@@ -2241,7 +2254,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                     timeField.SendKeys(time);
                 },
                 d => timeField.GetAttribute("value").IsValueEqualsTo(time),
-                new TimeSpan(0, 0, 9), 3,
+                TimeSpan.FromSeconds(9), 3,
                 failureCallback: () => throw new InvalidOperationException($"Timeout after 10 seconds. Expected: {time}. Actual: {timeField.GetAttribute("value")}")
             );
         }
@@ -2624,7 +2637,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                     expandCollapseButtons.First().Click(true);
                 }
 
-                var returnValue = new MultiValueOptionSet {Name = option.Name};
+                var returnValue = new MultiValueOptionSet { Name = option.Name };
 
                 xpath = AppElements.Xpath[AppReference.MultiSelect.SelectedRecordLabel].Replace("[NAME]", Elements.ElementId[option.Name]);
                 var labelItems = driver.FindElements(By.XPath(xpath));
@@ -2654,7 +2667,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 var dateField = driver.WaitUntilAvailable(xPath, $"Field: {field} Does not exist");
                 string strDate = dateField.GetAttribute("value");
                 if (strDate.IsEmptyValue())
-                    return (DateTime?) null;
+                    return (DateTime?)null;
 
                 var date = DateTime.Parse(strDate);
 
@@ -3347,7 +3360,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         /// <returns>True on success, False on failure to invoke any action</returns>
         internal BrowserCommandResult<bool> OpenAndClickPopoutMenu(By menuName, By menuItemName, int thinkTime = Constants.DefaultThinkTime)
         {
-            this.Browser.ThinkTime(thinkTime);
+            ThinkTime(thinkTime);
 
             return this.Execute($"Open menu", driver =>
             {
@@ -3371,7 +3384,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 
         internal BrowserCommandResult<bool> Delete(int thinkTime = Constants.DefaultThinkTime)
         {
-            this.Browser.ThinkTime(thinkTime);
+            ThinkTime(thinkTime);
 
             return this.Execute(GetOptions($"Delete Entity"), driver =>
             {
@@ -3390,7 +3403,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         internal BrowserCommandResult<bool> Assign(string userOrTeamToAssign, int thinkTime = Constants.DefaultThinkTime)
         {
             //Click the Assign Button on the Entity Record
-            this.Browser.ThinkTime(thinkTime);
+            ThinkTime(thinkTime);
 
             return this.Execute(GetOptions($"Assign Entity"), driver =>
             {
@@ -3406,7 +3419,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 
         internal BrowserCommandResult<bool> SwitchProcess(string processToSwitchTo, int thinkTime = Constants.DefaultThinkTime)
         {
-            this.Browser.ThinkTime(thinkTime);
+            ThinkTime(thinkTime);
 
             return this.Execute(GetOptions($"Switch BusinessProcessFlow"), driver =>
             {
@@ -3424,7 +3437,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 
         internal BrowserCommandResult<bool> CloseOpportunity(bool closeAsWon, int thinkTime = Constants.DefaultThinkTime)
         {
-            this.Browser.ThinkTime(thinkTime);
+            ThinkTime(thinkTime);
 
             var xPathQuery = closeAsWon
                 ? AppElements.Xpath[AppReference.Entity.CloseOpportunityWin]
@@ -3444,7 +3457,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 
         internal BrowserCommandResult<bool> CloseOpportunity(double revenue, DateTime closeDate, string description, int thinkTime = Constants.DefaultThinkTime)
         {
-            this.Browser.ThinkTime(thinkTime);
+            ThinkTime(thinkTime);
 
             return this.Execute(GetOptions($"Close Opportunity"), driver =>
             {
@@ -3540,7 +3553,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         /// <returns>True on success, Exception on failure to invoke any action</returns>
         internal BrowserCommandResult<bool> SelectTab(string tabName, string subTabName = "", int thinkTime = Constants.DefaultThinkTime)
         {
-            Browser.ThinkTime(thinkTime);
+            ThinkTime(thinkTime);
 
             return this.Execute($"Select Tab", driver =>
             {
@@ -3748,36 +3761,36 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                         //fieldElement.SendKeys(Keys.Enter);
 
                         fieldElement.Click();
-                        this.Browser.ThinkTime(250);
+                        ThinkTime(250);
                         fieldElement.Click();
-                        this.Browser.ThinkTime(250);
+                        ThinkTime(250);
                         fieldElement.SendKeys(Keys.Backspace);
-                        this.Browser.ThinkTime(250);
+                        ThinkTime(250);
                         fieldElement.SendKeys(Keys.Backspace);
-                        this.Browser.ThinkTime(250);
+                        ThinkTime(250);
                         fieldElement.SendKeys(Keys.Backspace);
-                        this.Browser.ThinkTime(250);
+                        ThinkTime(250);
                         fieldElement.SendKeys(date.ToString(format), true);
-                        this.Browser.ThinkTime(500);
+                        ThinkTime(500);
                         fieldElement.SendKeys(Keys.Tab);
-                        this.Browser.ThinkTime(250);
+                        ThinkTime(250);
                     }
                     else
                     {
                         fieldElement.Click();
-                        this.Browser.ThinkTime(250);
+                        ThinkTime(250);
                         fieldElement.Click();
-                        this.Browser.ThinkTime(250);
+                        ThinkTime(250);
                         fieldElement.SendKeys(Keys.Backspace);
-                        this.Browser.ThinkTime(250);
+                        ThinkTime(250);
                         fieldElement.SendKeys(Keys.Backspace);
-                        this.Browser.ThinkTime(250);
+                        ThinkTime(250);
                         fieldElement.SendKeys(Keys.Backspace);
-                        this.Browser.ThinkTime(250);
+                        ThinkTime(250);
                         fieldElement.SendKeys(date.ToString(format));
-                        this.Browser.ThinkTime(250);
+                        ThinkTime(250);
                         fieldElement.SendKeys(Keys.Tab);
-                        this.Browser.ThinkTime(250);
+                        ThinkTime(250);
                     }
                 }
                 else
@@ -3789,7 +3802,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 
         internal BrowserCommandResult<bool> NextStage(string stageName, Field businessProcessFlowField = null, int thinkTime = Constants.DefaultThinkTime)
         {
-            this.Browser.ThinkTime(thinkTime);
+            ThinkTime(thinkTime);
 
             return this.Execute(GetOptions($"Next Stage"), driver =>
             {
@@ -3870,7 +3883,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 
         internal BrowserCommandResult<bool> SetActive(string stageName = "", int thinkTime = Constants.DefaultThinkTime)
         {
-            this.Browser.ThinkTime(thinkTime);
+            ThinkTime(thinkTime);
 
             return this.Execute(GetOptions($"Set Active Stage: {stageName}"), driver =>
             {
@@ -3940,7 +3953,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         /// <example>xrmBrowser.GlobalSearch.Search("Contoso");</example>
         internal BrowserCommandResult<bool> GlobalSearch(string criteria, int thinkTime = Constants.DefaultThinkTime)
         {
-            Browser.ThinkTime(thinkTime);
+            ThinkTime(thinkTime);
 
             return this.Execute(GetOptions($"Global Search: {criteria}"), driver =>
             {
@@ -3979,7 +3992,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         /// <example>xrmBrowser.GlobalSearch.FilterWith("Account");</example>
         public BrowserCommandResult<bool> FilterWith(string entity, int thinkTime = Constants.DefaultThinkTime)
         {
-            Browser.ThinkTime(thinkTime);
+            ThinkTime(thinkTime);
 
             return this.Execute(GetOptions($"Filter With: {entity}"), driver =>
             {
@@ -4011,7 +4024,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         /// <example>xrmBrowser.GlobalSearch.Filter("Record Type", "Accounts");</example>
         public BrowserCommandResult<bool> Filter(string filterBy, string value, int thinkTime = Constants.DefaultThinkTime)
         {
-            Browser.ThinkTime(thinkTime);
+            ThinkTime(thinkTime);
 
             return this.Execute(GetOptions($"Filter With: {value}"), driver =>
             {
@@ -4035,7 +4048,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         /// <example>xrmBrowser.GlobalSearch.OpenRecord("Accounts",0);</example>
         public BrowserCommandResult<bool> OpenGlobalSearchRecord(string entity, int index, int thinkTime = Constants.DefaultThinkTime)
         {
-            Browser.ThinkTime(thinkTime);
+            ThinkTime(thinkTime);
 
             return this.Execute(GetOptions($"Open Global Search Record"), driver =>
             {
@@ -4093,7 +4106,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         /// <example>xrmBrowser.GlobalSearch.ChangeSearchType("Categorized");</example>
         public BrowserCommandResult<bool> ChangeSearchType(string type, int thinkTime = Constants.DefaultThinkTime)
         {
-            Browser.ThinkTime(thinkTime);
+            ThinkTime(thinkTime);
 
             return this.Execute(GetOptions("Change Search Type"), driver =>
             {
@@ -4120,7 +4133,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 
         internal BrowserCommandResult<bool> SelectDashboard(string dashboardName, int thinkTime = Constants.DefaultThinkTime)
         {
-            this.Browser.ThinkTime(thinkTime);
+            ThinkTime(thinkTime);
 
             return this.Execute(GetOptions($"Select Dashboard"), driver =>
             {

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -54,7 +54,6 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                     var testModeUri = uri + queryParams;
 
                     driver.Navigate().GoToUrl(testModeUri);
-
                 }
 
                 WaitForMainPage();
@@ -67,6 +66,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         public string[] OnlineDomains { get; set; }
 
         #region PageWaits
+
         internal void WaitForLoginPage()
         {
             IWebDriver driver = this.Browser.Driver;
@@ -75,15 +75,15 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 , TimeSpan.FromSeconds(60),
                 e =>
                 {
-                             //determine if we landed on the Unified Client Main page
+                    //determine if we landed on the Unified Client Main page
                     if (driver.HasElement(By.XPath(Elements.Xpath[Reference.Login.CrmUCIMainPage])))
-                             {
+                    {
                         driver.WaitForPageToLoad();
                         driver.WaitForTransaction();
-                             }
-                             else //else we landed on the Web Client main page or app picker page
+                    }
+                    else //else we landed on the Web Client main page or app picker page
                         SwitchToDefaultContent(driver);
-                         },
+                },
                 "Login page failed."
             );
         }
@@ -98,9 +98,11 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 driver.WaitForTransaction();
             }
         }
+
         #endregion
 
         #region Login
+
         internal BrowserCommandResult<LoginResult> Login(Uri uri)
         {
             var username = Browser.Options.Credentials.Username;
@@ -142,7 +144,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 
                 if (!waitingForOtc)
                     throw new Exception($"Login page failed. {Reference.Login.UserId} not found.");
-                }
+            }
 
             if (!waitingForOtc)
             {
@@ -161,7 +163,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 
                 EnterPassword(driver, password);
                 ThinkTime(1000);
-                }
+            }
 
             EnterOneTimeCode(driver, mfaSecrectKey);
 
@@ -173,7 +175,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         }
 
         private static bool IsUserAlreadyLogged(IWebDriver driver)
-                {
+        {
             var xpathToMainPage = By.XPath(Elements.Xpath[Reference.Login.CrmMainPage]);
             bool result = driver.HasElement(xpathToMainPage);
             return result;
@@ -194,7 +196,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         }
 
         private bool EnterUserName(IWebDriver driver, SecureString username)
-                    {
+        {
             var input = driver.WaitUntilAvailable(By.XPath(Elements.Xpath[Reference.Login.UserId]), new TimeSpan(0, 0, 30));
             if (input == null)
                 return false;
@@ -202,14 +204,14 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             input.SendKeys(username.ToUnsecureString());
             input.SendKeys(Keys.Enter);
             return true;
-                    }
+        }
 
         private static void EnterPassword(IWebDriver driver, SecureString password)
         {
             var input = driver.FindElement(By.XPath(Elements.Xpath[Reference.Login.LoginPassword]));
             input.SendKeys(password.ToUnsecureString());
             input.Submit();
-                }
+        }
 
         private static void EnterOneTimeCode(IWebDriver driver, SecureString mfaSecrectKey)
         {
@@ -223,7 +225,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                     input.SendKeys(oneTimeCode);
                     input.Submit();
                     return;
-            }
+                }
                 catch (Exception e)
                 {
                     Trace.TraceWarning($"An Error ocur entering OTC. Exception: {e}");
@@ -252,13 +254,14 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             //Switch Back to Default Content for Navigation Steps
             driver.SwitchTo().DefaultContent();
         }
-        
+
         private static void SwitchToMainFrame(IWebDriver driver)
         {
             driver.WaitForPageToLoad();
             driver.SwitchTo().Frame(0);
             driver.WaitForPageToLoad();
         }
+
         internal BrowserCommandResult<LoginResult> PassThroughLogin(Uri uri)
         {
             return this.Execute(GetOptions("Pass Through Login"), driver =>
@@ -324,6 +327,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         #endregion
 
         #region Navigation
+
         internal BrowserCommandResult<bool> OpenApp(string appName, int thinkTime = Constants.DefaultThinkTime)
         {
             Browser.ThinkTime(thinkTime);
@@ -344,10 +348,10 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 InitializeModes();
                 return true;
             });
-                }
+        }
 
         private bool TryOpenAppFromMenu(IWebDriver driver, string appName, string appMenuButton)
-                {
+        {
             try
             {
                 var xpathToAppMenu = By.XPath(AppElements.Xpath[appMenuButton]);
@@ -357,13 +361,13 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                     appMenu.Click(true);
                     OpenAppFromMenu(driver, appName);
                 }
-                return found;
-                }
-            catch (Exception e)
-                {
-               throw  new InvalidOperationException($"App Button {appMenuButton} not found.", e);
-                    }
 
+                return found;
+            }
+            catch (Exception e)
+            {
+                throw new InvalidOperationException($"App Button {appMenuButton} not found.", e);
+            }
         }
 
         internal void OpenAppFromMenu(IWebDriver driver, string appName)
@@ -393,7 +397,8 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             {
                 var appTile = tileContainer.FindElement(By.XPath(AppElements.Xpath[AppReference.Navigation.UCIAppTile].Replace("[NAME]", appName)));
                 appTile.Click(true);
-        }
+            }
+
             return success;
         }
 
@@ -451,15 +456,15 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 }
 
                 WaitForLoadArea(driver);
-                    return true;
+                return true;
             });
-                }
+        }
 
         private static void WaitForLoadArea(IWebDriver driver)
         {
-                driver.WaitUntilVisible(By.XPath(AppElements.Xpath[AppReference.Grid.Container]));
-                driver.WaitForPageToLoad();
-                driver.WaitForTransaction();
+            driver.WaitUntilVisible(By.XPath(AppElements.Xpath[AppReference.Grid.Container]));
+            driver.WaitForPageToLoad();
+            driver.WaitForTransaction();
         }
 
         public BrowserCommandResult<bool> OpenSubArea(string subarea)
@@ -485,14 +490,14 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         }
 
         public BrowserCommandResult<bool> OpenArea(string subarea)
-                {
+        {
             return Execute(GetOptions("Open Unified Interface Area"), driver =>
-                    {
+            {
                 var success = TryOpenArea(subarea);
                 WaitForLoadArea(driver);
                 return success;
             });
-                    }
+        }
 
         private bool TryOpenArea(string area)
         {
@@ -506,7 +511,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 menuItem.Click(true);
 
             return foundMenuItem;
-                }
+        }
 
         public BrowserCommandResult<Dictionary<string, IWebElement>> OpenAreas(string area, int thinkTime = Constants.DefaultThinkTime)
         {
@@ -521,6 +526,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 return areas;
             });
         }
+
         public Dictionary<string, IWebElement> OpenMenu(int thinkTime = Constants.DefaultThinkTime)
         {
             return this.Execute(GetOptions("Open Menu"), driver =>
@@ -529,8 +535,9 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 
                 var result = GetMenuItemsFrom(driver, AppReference.Navigation.AreaMenu);
                 return result;
-                                            });
+            });
         }
+
         public Dictionary<string, IWebElement> OpenMenuFallback(string area, int thinkTime = Constants.DefaultThinkTime)
         {
             return this.Execute(GetOptions("Open Menu"), driver =>
@@ -565,31 +572,35 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 
                 bool isVisible = moreButton.IsVisible();
                 if (isVisible)
-                            {
+                {
                     moreButton.Click();
                     AddMenuItemsFrom(driver, AppReference.Navigation.AreaMoreMenu, dictionary);
-                            }
+                }
                 else
-                        {
+                {
                     var singleItem = driver.FindElement(By.XPath(AppElements.Xpath[AppReference.Navigation.SiteMapSingleArea].Replace("[NAME]", area)));
-                    char[] trimCharacters = { '', '\r', '\n', '', '', '' };
+                    char[] trimCharacters =
+                    {
+                        '', '\r', '\n', '',
+                        '', ''
+                    };
 
                     dictionary.Add(singleItem.Text.Trim(trimCharacters).ToLowerString(), singleItem);
                 }
 
                 return dictionary;
-                        });
-                }
+            });
+        }
 
         private static Dictionary<string, IWebElement> GetMenuItemsFrom(IWebDriver driver, string referenceToMenuItemsContainer)
-                {
+        {
             var result = new Dictionary<string, IWebElement>();
             AddMenuItemsFrom(driver, referenceToMenuItemsContainer, result);
             return result;
         }
 
         private static void AddMenuItemsFrom(IWebDriver driver, string referenceToMenuItemsContainer, Dictionary<string, IWebElement> dictionary)
-                    {
+        {
             driver.WaitUntilAvailable(By.XPath(AppElements.Xpath[referenceToMenuItemsContainer]),
                 TimeSpan.FromSeconds(2),
                 menu => AddMenuItems(menu, dictionary),
@@ -598,7 +609,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         }
 
         private static Dictionary<string, IWebElement> GetMenuItems(IWebElement menu)
-                                               {
+        {
             var result = new Dictionary<string, IWebElement>();
             AddMenuItems(menu, result);
             return result;
@@ -606,15 +617,15 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 
         private static void AddMenuItems(IWebElement menu, Dictionary<string, IWebElement> dictionary)
         {
-                                                   var menuItems = menu.FindElements(By.TagName("li"));
-                                                   foreach (var item in menuItems)
-                                                   {
+            var menuItems = menu.FindElements(By.TagName("li"));
+            foreach (var item in menuItems)
+            {
                 string key = item.Text.ToLowerString();
                 if (dictionary.ContainsKey(key))
                     continue;
                 dictionary.Add(key, item);
-                                                   }
-                    }
+            }
+        }
 
         internal BrowserCommandResult<Dictionary<string, IWebElement>> OpenSubMenu(string subarea)
         {
@@ -626,7 +637,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 var hasPinnedSitemapEntity = driver.HasElement(By.XPath(AppElements.Xpath[AppReference.Navigation.PinnedSitemapEntity]));
                 if (!hasPinnedSitemapEntity)
                 {
-                        // Close SiteMap launcher since it is open
+                    // Close SiteMap launcher since it is open
                     var xpathToLauncherCloseButton = By.XPath(AppElements.Xpath[AppReference.Navigation.SiteMapLauncherCloseButton]);
                     driver.ClickWhenAvailable(xpathToLauncherCloseButton);
 
@@ -643,32 +654,33 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                         if (string.IsNullOrEmpty(id))
                             continue;
 
-                            // Filter out duplicate entity keys - click the first one in the list
+                        // Filter out duplicate entity keys - click the first one in the list
                         var key = subItem.Text.ToLowerString();
                         if (!dictionary.ContainsKey(key))
                             dictionary.Add(key, subItem);
-                        }
-                    return dictionary;
                     }
 
-                    //Sitemap with enableunifiedinterfaceshellrefresh enabled
-                    var menuShell = driver.FindElements(By.XPath(AppElements.Xpath[AppReference.Navigation.SubAreaContainer]));
+                    return dictionary;
+                }
 
-                    //The menu is broke into multiple sections. Gather all items.
-                    foreach (IWebElement menuSection in menuShell)
+                //Sitemap with enableunifiedinterfaceshellrefresh enabled
+                var menuShell = driver.FindElements(By.XPath(AppElements.Xpath[AppReference.Navigation.SubAreaContainer]));
+
+                //The menu is broke into multiple sections. Gather all items.
+                foreach (IWebElement menuSection in menuShell)
+                {
+                    var menuItems = menuSection.FindElements(By.XPath(AppElements.Xpath[AppReference.Navigation.SitemapMenuItems]));
+
+                    foreach (var menuItem in menuItems)
                     {
-                        var menuItems = menuSection.FindElements(By.XPath(AppElements.Xpath[AppReference.Navigation.SitemapMenuItems]));
-
-                        foreach (var menuItem in menuItems)
-                        {
                         var text = menuItem.Text.ToLowerString();
                         if (string.IsNullOrEmpty(text))
                             continue;
 
                         if (!dictionary.ContainsKey(text))
                             dictionary.Add(text, menuItem);
-                            }
-                        }
+                    }
+                }
 
                 return dictionary;
             });
@@ -755,12 +767,13 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             {
                 driver.WaitUntilClickable(By.XPath(AppElements.Xpath[AppReference.Navigation.SearchButton]),
                     TimeSpan.FromSeconds(5),
-                d => { driver.ClickWhenAvailable(By.XPath(AppElements.Xpath[AppReference.Navigation.SearchButton])); },
+                    d => { driver.ClickWhenAvailable(By.XPath(AppElements.Xpath[AppReference.Navigation.SearchButton])); },
                     "The Global Search button is not available."
                 );
                 return true;
             });
         }
+
         internal BrowserCommandResult<bool> ClickQuickLaunchButton(string toolTip, int thinkTime = Constants.DefaultThinkTime)
         {
             Browser.ThinkTime(thinkTime);
@@ -808,6 +821,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         #endregion
 
         #region Dialogs
+
         internal bool SwitchToDialog(int frameIndex = 0)
         {
             var index = "";
@@ -822,8 +836,8 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             {
                 //wait for the content panel to render
                 Browser.Driver.WaitUntilAvailable(By.XPath(Elements.Xpath[Reference.Frames.DialogFrame].Replace("[INDEX]", index)),
-                                                  TimeSpan.FromSeconds(2),
-                                                  d => { Browser.Driver.SwitchTo().Frame(Elements.ElementId[Reference.Frames.DialogFrameId].Replace("[INDEX]", index)); });
+                    TimeSpan.FromSeconds(2),
+                    d => { Browser.Driver.SwitchTo().Frame(Elements.ElementId[Reference.Frames.DialogFrameId].Replace("[INDEX]", index)); });
                 return true;
             }
             else
@@ -831,8 +845,10 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 // need to add this functionality
                 //SwitchToPopup();
             }
+
             return true;
         }
+
         internal BrowserCommandResult<bool> CloseWarningDialog()
         {
             return this.Execute(GetOptions($"Close Warning Dialog"), driver =>
@@ -848,9 +864,11 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                     var closeBtn = dialogFooter.FindElement(By.XPath(Elements.Xpath[Reference.Dialogs.WarningCloseButton]));
                     closeBtn.Click();
                 }
+
                 return true;
             });
         }
+
         internal BrowserCommandResult<bool> ConfirmationDialog(bool ClickConfirmButton)
         {
             //Passing true clicks the confirm button.  Passing false clicks the Cancel button.
@@ -875,9 +893,11 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 
                     buttonToClick.Click();
                 }
+
                 return true;
             });
         }
+
         internal BrowserCommandResult<bool> AssignDialog(Dialogs.AssignTo to, string userOrTeamName)
         {
             return this.Execute(GetOptions($"Assign to User or Team Dialog"), driver =>
@@ -927,11 +947,12 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                     //Click Assign
                     var okButton = driver.FindElement(By.XPath(AppElements.Xpath[AppReference.Dialogs.AssignDialogOKButton]));
                     okButton.Click(true);
-
                 }
+
                 return true;
             });
         }
+
         internal BrowserCommandResult<bool> SwitchProcessDialog(string processToSwitchTo)
         {
             return this.Execute(GetOptions($"Switch Process Dialog"), driver =>
@@ -958,6 +979,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 return true;
             });
         }
+
         internal BrowserCommandResult<bool> CloseOpportunityDialog(bool clickOK)
         {
             return this.Execute(GetOptions($"Close Opportunity Dialog"), driver =>
@@ -975,9 +997,11 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 
                     driver.ClickWhenAvailable(By.XPath(xPath), TimeSpan.FromSeconds(5), "The Close Opportunity dialog is not available.");
                 }
+
                 return true;
             });
         }
+
         internal BrowserCommandResult<bool> HandleSaveDialog()
         {
             //If you click save and something happens, handle it.  Duplicate Detection/Errors/etc...
@@ -1029,7 +1053,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 
             var result = GetListItems(dialog, titlePath, elementPath);
             return result;
-                }
+        }
 
         private static List<ListItem> GetListItems(IWebElement dialog, By titlePath, By elementPath)
         {
@@ -1047,15 +1071,15 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 
                 var element = divLinks[0];
                 var id = element.GetAttribute("id");
-                    var title = titleLinks[0].GetAttribute("innerText");
+                var title = titleLinks[0].GetAttribute("innerText");
 
                 list.Add(new ListItem
-                    {
+                {
                     Id = id,
-                        Title = title,
+                    Title = title,
                     Element = element
-                    });
-                }
+                });
+            }
 
             return list;
         }
@@ -1063,6 +1087,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         #endregion
 
         #region CommandBar
+
         internal BrowserCommandResult<bool> ClickCommand(string name, string subname = "", bool moreCommands = false, int thinkTime = Constants.DefaultThinkTime)
         {
             this.Browser.ThinkTime(thinkTime);
@@ -1126,7 +1151,6 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                     }
                     else
                         throw new InvalidOperationException($"No sub command with the name '{subname}' exists inside of Commandbar.");
-
                 }
 
                 driver.WaitForTransaction();
@@ -1234,6 +1258,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         #endregion
 
         #region Grid
+
         public BrowserCommandResult<Dictionary<string, string>> OpenViewPicker(int thinkTime = Constants.DefaultThinkTime)
         {
             Browser.ThinkTime(thinkTime);
@@ -1243,7 +1268,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 driver.ClickWhenAvailable(By.XPath(AppElements.Xpath[AppReference.Grid.ViewSelector]),
                     TimeSpan.FromSeconds(20),
                     "Unable to click the View Picker"
-                    );
+                );
 
                 var viewContainer = driver.FindElement(By.XPath(AppElements.Xpath[AppReference.Grid.ViewContainer]));
                 var viewItems = viewContainer.FindElements(By.TagName("li"));
@@ -1254,10 +1279,12 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                     var role = viewItem.GetAttribute("role");
                     if (role == "option")
                         dictionary.Add(viewItem.Text, viewItem.GetAttribute("id"));
-                    }
+                }
+
                 return dictionary;
             });
         }
+
         internal BrowserCommandResult<bool> SwitchView(string viewName, int thinkTime = Constants.DefaultThinkTime)
         {
             this.Browser.ThinkTime(thinkTime);
@@ -1277,6 +1304,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 return true;
             });
         }
+
         internal BrowserCommandResult<bool> OpenRecord(int index, int thinkTime = Constants.DefaultThinkTime, bool checkRecord = false)
         {
             this.Browser.ThinkTime(thinkTime);
@@ -1306,6 +1334,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 return true;
             });
         }
+
         internal BrowserCommandResult<bool> Search(string searchCriteria, bool clearByDefault = true, int thinkTime = Constants.DefaultThinkTime)
         {
             this.Browser.ThinkTime(thinkTime);
@@ -1364,7 +1393,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                         var cells = row.FindElements(By.ClassName("wj-cell"));
                         var currentindex = 0;
                         var link =
-                           $"{new Uri(driver.Url).Scheme}://{new Uri(driver.Url).Authority}/main.aspx?etn={datalpid[2]}&pagetype=entityrecord&id=%7B{datalpid[3]}%7D";
+                            $"{new Uri(driver.Url).Scheme}://{new Uri(driver.Url).Authority}/main.aspx?etn={datalpid[2]}&pagetype=entityrecord&id=%7B{datalpid[3]}%7D";
 
                         var item = new GridItem
                         {
@@ -1391,15 +1420,19 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                                 {
                                     item[id] = cellData.Replace("-", "");
                                 }
+
                                 currentindex++;
                             }
+
                             returnList.Add(item);
                         }
                     }
                 }
+
                 return returnList;
             });
         }
+
         internal BrowserCommandResult<bool> NextPage(int thinkTime = Constants.DefaultThinkTime)
         {
             this.Browser.ThinkTime(thinkTime);
@@ -1413,6 +1446,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 return true;
             });
         }
+
         internal BrowserCommandResult<bool> PreviousPage(int thinkTime = Constants.DefaultThinkTime)
         {
             this.Browser.ThinkTime(thinkTime);
@@ -1426,6 +1460,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 return true;
             });
         }
+
         internal BrowserCommandResult<bool> FirstPage(int thinkTime = Constants.DefaultThinkTime)
         {
             this.Browser.ThinkTime(thinkTime);
@@ -1439,6 +1474,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 return true;
             });
         }
+
         internal BrowserCommandResult<bool> SelectAll(int thinkTime = Constants.DefaultThinkTime)
         {
             this.Browser.ThinkTime(thinkTime);
@@ -1452,6 +1488,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 return true;
             });
         }
+
         public BrowserCommandResult<bool> ShowChart(int thinkTime = Constants.DefaultThinkTime)
         {
             Browser.ThinkTime(thinkTime);
@@ -1472,6 +1509,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 return true;
             });
         }
+
         public BrowserCommandResult<bool> HideChart(int thinkTime = Constants.DefaultThinkTime)
         {
             Browser.ThinkTime(thinkTime);
@@ -1492,6 +1530,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 return true;
             });
         }
+
         public BrowserCommandResult<bool> FilterByLetter(char filter, int thinkTime = Constants.DefaultThinkTime)
         {
             Browser.ThinkTime(thinkTime);
@@ -1518,6 +1557,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 return true;
             });
         }
+
         public BrowserCommandResult<bool> FilterByAll(int thinkTime = Constants.DefaultThinkTime)
         {
             Browser.ThinkTime(thinkTime);
@@ -1541,6 +1581,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 return true;
             });
         }
+
         public BrowserCommandResult<bool> SelectRecord(int index, int thinkTime = Constants.DefaultThinkTime)
         {
             Browser.ThinkTime(thinkTime);
@@ -1553,10 +1594,11 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 if (row == null)
                     throw new Exception($"Row with index: {index} does not exist.");
 
-                    row.Click();
+                row.Click();
                 return true;
             });
         }
+
         public BrowserCommandResult<bool> SwitchChart(string chartName, int thinkTime = Constants.DefaultThinkTime)
         {
             Browser.ThinkTime(thinkTime);
@@ -1577,6 +1619,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 return true;
             });
         }
+
         public BrowserCommandResult<bool> Sort(string columnName, int thinkTime = Constants.DefaultThinkTime)
         {
             Browser.ThinkTime(thinkTime);
@@ -1594,9 +1637,11 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 return true;
             });
         }
+
         #endregion
 
         #region RelatedGrid
+
         /// <summary>
         /// Opens the grid record.
         /// </summary>
@@ -1648,9 +1693,11 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 
                     driver.WaitForTransaction();
                 }
+
                 return true;
             });
         }
+
         #endregion
 
         #region Subgrid
@@ -1806,9 +1853,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 
             return this.Execute(GetOptions("Close Record Set Navigator"), driver =>
             {
-                var closeSpan =
-                    driver.HasElement(By.XPath(AppElements.Xpath[AppReference.Entity.RecordSetNavCollapseIcon]));
-
+                var closeSpan = driver.HasElement(By.XPath(AppElements.Xpath[AppReference.Entity.RecordSetNavCollapseIcon]));
                 if (closeSpan)
                 {
                     driver.FindElement(By.XPath(AppElements.Xpath[AppReference.Entity.RecordSetNavCollapseIconParent])).Click();
@@ -1839,15 +1884,17 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 if (!found)
                     throw new NoSuchElementException($"Field with name {field} does not exist.");
 
-                        input.Click();
-                            input.SendKeys(Keys.Control + "a");
-                            input.SendKeys(Keys.Backspace);
+                input.Click();
+                input.SendKeys(Keys.Control + "a");
+                input.SendKeys(Keys.Backspace);
 
                 if (!string.IsNullOrWhiteSpace(value))
-                            input.SendKeys(value, true);
+                    input.SendKeys(value, true);
 
                 // Needed to transfer focus out of special fields (email or phone)
-                driver.ClearFocus();
+                var label = fieldContainer.ClickIfVisible(By.TagName("label"));
+                if(label == null)
+                    driver.ClearFocus();
 
                 return true;
             });
@@ -1875,19 +1922,19 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         }
 
         private void TrySetValue(IWebElement fieldContainer, LookupItem control, int index)
-                {
+        {
             IWebElement input;
             bool found = fieldContainer.TryFindElement(By.TagName("input"), out input);
             string value = control.Value?.Trim();
             if (found)
             {
-                    input.SendKeys(Keys.Control + "a");
-                    input.SendKeys(Keys.Backspace);
+                input.SendKeys(Keys.Control + "a");
+                input.SendKeys(Keys.Backspace);
                 input.SendKeys(value, true);
-                }
+            }
 
             TrySetValue(fieldContainer, control, value, index);
-                }
+        }
 
         /// <summary>
         /// Sets the value of an ActivityParty Lookup.
@@ -1918,29 +1965,31 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             IWebElement input;
             bool found = fieldContainer.TryFindElement(By.TagName("input"), out input);
 
-                foreach (var control in controls)
-                {
+            foreach (var control in controls)
+            {
                 var value = control.Value?.Trim();
                 if (found)
-                    {
+                {
                     if (string.IsNullOrWhiteSpace(value))
                         input.Click();
                     else
-                        {
+                    {
                         input.SendKeys(value, true);
-                            input.SendKeys(Keys.Tab);
-                            input.SendKeys(Keys.Enter);
-                        }
-                        }
-                TrySetValue(fieldContainer, control, value, index);
+                        input.SendKeys(Keys.Tab);
+                        input.SendKeys(Keys.Enter);
                     }
+                }
+
+                TrySetValue(fieldContainer, control, value, index);
+            }
+
             input.SendKeys(Keys.Escape); // IE wants to keep the flyout open on multi-value fields, this makes sure it closes
         }
 
         private void TrySetValue(ISearchContext container, LookupItem control, string value, int index)
-                    {
+        {
             if (value == null)
-                        throw new InvalidOperationException($"No value has been provided for the LookupItem {control.Name}. Please provide a value or an empty string and try again.");
+                throw new InvalidOperationException($"No value has been provided for the LookupItem {control.Name}. Please provide a value or an empty string and try again.");
 
             if (value == string.Empty)
                 SetLookupByIndex(container, control, index);
@@ -2012,12 +2061,12 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         }
 
         private static void TrySetValue(IWebElement fieldContainer, OptionSet control)
-                {
+        {
             var value = control.Value;
             bool success = fieldContainer.TryFindElement(By.TagName("select"), out IWebElement select);
             if (success)
             {
-                    var options = select.FindElements(By.TagName("option"));
+                var options = select.FindElements(By.TagName("option"));
                 SelectOption(options, value);
                 return;
             }
@@ -2025,26 +2074,26 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             var name = control.Name;
             var hasStatusCombo = fieldContainer.HasElement(By.XPath(AppElements.Xpath[AppReference.Entity.EntityOptionsetStatusCombo].Replace("[NAME]", name)));
             if (hasStatusCombo)
-                    {
-                    // This is for statuscode (type = status) that should act like an optionset doesn't doesn't follow the same pattern when rendered
+            {
+                // This is for statuscode (type = status) that should act like an optionset doesn't doesn't follow the same pattern when rendered
                 fieldContainer.ClickWhenAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.EntityOptionsetStatusComboButton].Replace("[NAME]", name)));
 
                 var listBox = fieldContainer.FindElement(By.XPath(AppElements.Xpath[AppReference.Entity.EntityOptionsetStatusComboList].Replace("[NAME]", name)));
 
-                    var options = listBox.FindElements(By.TagName("li"));
+                var options = listBox.FindElements(By.TagName("li"));
                 SelectOption(options, value);
 
                 return;
-                    }
+            }
 
             throw new InvalidOperationException($"OptionSet Field: '{name}' does not exist");
-                }
+        }
 
         private static void SelectOption(ReadOnlyCollection<IWebElement> options, string value)
-                {
+        {
             var selectedOption = options.FirstOrDefault(op => op.Text == value || op.GetAttribute("value") == value);
             selectedOption.Click(true);
-                }
+        }
 
         /// <summary>
         /// Sets the value of a Boolean Item.
@@ -2129,21 +2178,37 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         }
 
         public BrowserCommandResult<bool> SetValue(DateTimeControl control)
-            => Execute(GetOptions($"Set Date/Time Value: {control.Name}"), driver => SetValue(driver, control));
+            => Execute(GetOptions($"Set Date/Time Value: {control.Name}"),
+                driver => TrySetValue(driver, container: driver, control: control));
 
-        private static bool SetValue(IWebDriver driver, DateTimeControl control)
+        private static bool TrySetValue(IWebDriver driver, ISearchContext container, DateTimeControl control)
+        {
+            TrySetDateValue(driver, container, control);
+            TrySetTime(driver, container, control);
+            
+            if(container is IWebElement parent)
+                parent.Click(true);
+            else 
+                driver.ClearFocus();
+
+            return true;
+        }
+
+        private static void TrySetDateValue(IWebDriver driver, ISearchContext container, DateTimeControl control)
         {
             string controlName = control.Name;
-            var xPath = By.XPath(AppElements.Xpath[AppReference.Entity.FieldControlDateTimeInputUCI].Replace("[FIELD]", controlName));
+            var xpathToInput = By.XPath(AppElements.Xpath[AppReference.Entity.FieldControlDateTimeInputUCI].Replace("[FIELD]", controlName));
+            var dateField = container.WaitUntilAvailable(xpathToInput, $"DateTime Field: '{controlName}' does not exist");
+            TrySetDateValue(driver, dateField, control.DateAsString);
+        }
 
-            var dateField = driver.WaitUntilAvailable(xPath, $"DateTime Field: '{controlName}' does not exist");
-           
+        private static void TrySetDateValue(IWebDriver driver, IWebElement dateField, string date)
+        {
             var strExpanded = dateField.GetAttribute("aria-expanded");
             bool success = bool.TryParse(strExpanded, out var isCalendarExpanded);
             if (success && isCalendarExpanded)
                 dateField.Click(); // close calendar
-            
-            string date = control.DateAsString;
+
             driver.RepeatUntil(() =>
                 {
                     driver.DoubleClick(dateField);
@@ -2153,31 +2218,32 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 new TimeSpan(0, 0, 9), 3,
                 failureCallback: () => throw new InvalidOperationException($"Timeout after 10 seconds. Expected: {date}. Actual: {dateField.GetAttribute("value")}")
             );
+        }
 
-            // Try Set Time
-            var timeFieldXPath = By.XPath(AppElements.Xpath[AppReference.Entity.FieldControlDateTimeTimeInputUCI].Replace("[FIELD]", controlName));
-            success = driver.TryFindElement(timeFieldXPath, out var timeField);
+        private static void TrySetTime(IWebDriver driver, ISearchContext container, DateTimeControl control)
+        {
+            By timeFieldXPath = By.XPath(AppElements.Xpath[AppReference.Entity.FieldControlDateTimeTimeInputUCI].Replace("[FIELD]", control.Name));
+            var success = container.TryFindElement(timeFieldXPath, out var timeField);
             if (success)
-            {
-                timeField.Click();
-                // wait until the time get updated after change/clear the date
-                driver.WaitForTransaction();
+                TrySetTime(driver, timeField, control.TimeAsString);
+        }
 
-                string time = control.TimeAsString;
-                driver.RepeatUntil(() =>
-                    {
-                        timeField.Clear();
-                        timeField.Click();
-                        timeField.SendKeys(time);
-                    },
-                    d => timeField.GetAttribute("value").IsValueEqualsTo(time),
-                    new TimeSpan(0, 0, 9), 3,
-                    failureCallback: () => throw new InvalidOperationException($"Timeout after 10 seconds. Expected: {time}. Actual: {timeField.GetAttribute("value")}")
-                );
-            }
-            
-            driver.ClearFocus();
-            return true;
+        private static void TrySetTime(IWebDriver driver, IWebElement timeField, string time)
+        {
+            // click & wait until the time get updated after change/clear the date
+            timeField.Click();
+            driver.WaitForTransaction();
+
+            driver.RepeatUntil(() =>
+                {
+                    timeField.Clear();
+                    timeField.Click();
+                    timeField.SendKeys(time);
+                },
+                d => timeField.GetAttribute("value").IsValueEqualsTo(time),
+                new TimeSpan(0, 0, 9), 3,
+                failureCallback: () => throw new InvalidOperationException($"Timeout after 10 seconds. Expected: {time}. Actual: {timeField.GetAttribute("value")}")
+            );
         }
 
 
@@ -2199,6 +2265,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 {
                     AddMultiOptions(option);
                 }
+
                 return true;
             });
         }
@@ -2246,6 +2313,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                         driver.FindElements(By.XPath(xpath)).First().Click(true);
                     }
                 }
+
                 return true;
             });
         }
@@ -2290,6 +2358,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 {
                     divElements.First().Click(true);
                 }
+
                 return true;
             });
         }
@@ -2302,7 +2371,6 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 returnField.Name = field;
 
                 return returnField;
-
             });
         }
 
@@ -2362,26 +2430,27 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         private static string TryGetValue(IWebElement fieldContainer, LookupItem control)
         {
             Exception ex = null;
-                try
-                {
+            try
+            {
                 bool found = fieldContainer.TryFindElement(By.TagName("input"), out var input);
                 if (found)
-                    {
+                {
                     string lookupValue = input.GetAttribute("value");
                     return lookupValue;
-                    }
+                }
 
                 found = fieldContainer.TryFindElement(By.XPath(".//label"), out var label);
                 if (found)
-                    {
+                {
                     string lookupValue = label.GetAttribute("innerText");
                     return lookupValue;
-                    }
-                    }
-            catch (Exception e)
-                {
-                ex = e;
                 }
+            }
+            catch (Exception e)
+            {
+                ex = e;
+            }
+
             throw new InvalidOperationException($"Field: {control.Name} Does not exist", ex);
         }
 
@@ -2411,34 +2480,39 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             var xpathToExpandButton = By.XPath(AppElements.Xpath[AppReference.Entity.LookupFieldExpandCollapseButton].Replace("[NAME]", controlName));
             bool expandButtonFound = fieldContainer.TryFindElement(xpathToExpandButton, out var collapseButton);
             if (expandButtonFound)
-                {
+            {
                 collapseButton.Click(true);
 
                 int count = existingValues.Count;
                 fieldContainer.WaitUntil(fc => fc.FindElements(xpathToExistingValues).Count > count);
 
                 existingValues = fieldContainer.FindElements(xpathToExistingValues);
-                }
+            }
 
             Exception ex = null;
-                try
-                {
+            try
+            {
                 if (existingValues.Count > 0)
+                {
+                    char[] trimCharacters =
                     {
-                        char[] trimCharacters = { '', '\r', '\n', '', '', '' }; //IE can return line breaks
+                        '', '\r', '\n', '',
+                        '', ''
+                    }; //IE can return line breaks
                     string[] lookupValues = existingValues.Select(v => v.GetAttribute("innerText").Trim(trimCharacters)).ToArray();
                     return lookupValues;
-                    }
+                }
 
                 if (fieldContainer.FindElements(By.TagName("input")).Any())
                     return null;
-                    }
+            }
             catch (Exception e)
-                    {
+            {
                 ex = e;
-                    }
+            }
+
             throw new InvalidOperationException($"Field: {controlName} Does not exist", ex);
-                }
+        }
 
         /// <summary>
         /// Gets the value of a picklist or status field.
@@ -2458,32 +2532,32 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         }
 
         private static string TryGetValue(IWebElement fieldContainer, OptionSet control)
-                {
+        {
             bool success = fieldContainer.TryFindElement(By.TagName("select"), out IWebElement select);
             if (success)
             {
-                    var options = select.FindElements(By.TagName("option"));
+                var options = select.FindElements(By.TagName("option"));
                 string result = GetSelectedOption(options);
                 return result;
-                    }
+            }
 
             var name = control.Name;
             var hasStatusCombo = fieldContainer.HasElement(By.XPath(AppElements.Xpath[AppReference.Entity.EntityOptionsetStatusCombo].Replace("[NAME]", name)));
             if (hasStatusCombo)
-                {
-                    // This is for statuscode (type = status) that should act like an optionset doesn't doesn't follow the same pattern when rendered
+            {
+                // This is for statuscode (type = status) that should act like an optionset doesn't doesn't follow the same pattern when rendered
                 var valueSpan = fieldContainer.FindElement(By.XPath(AppElements.Xpath[AppReference.Entity.EntityOptionsetStatusTextValue].Replace("[NAME]", name)));
                 return valueSpan.Text;
             }
 
             throw new InvalidOperationException($"OptionSet Field: '{name}' does not exist");
-                }
+        }
 
         private static string GetSelectedOption(ReadOnlyCollection<IWebElement> options)
-                {
+        {
             var selectedOption = options.FirstOrDefault(op => op.Selected);
             return selectedOption?.Text ?? string.Empty;
-                }
+        }
 
         /// <summary>
         /// Sets the value of a Boolean Item.
@@ -2550,7 +2624,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                     expandCollapseButtons.First().Click(true);
                 }
 
-                var returnValue = new MultiValueOptionSet { Name = option.Name };
+                var returnValue = new MultiValueOptionSet {Name = option.Name};
 
                 xpath = AppElements.Xpath[AppReference.MultiSelect.SelectedRecordLabel].Replace("[NAME]", Elements.ElementId[option.Name]);
                 var labelItems = driver.FindElements(By.XPath(xpath));
@@ -2579,7 +2653,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 
                 var dateField = driver.WaitUntilAvailable(xPath, $"Field: {field} Does not exist");
                 string strDate = dateField.GetAttribute("value");
-                if(strDate.IsEmptyValue())
+                if (strDate.IsEmptyValue())
                     return (DateTime?) null;
 
                 var date = DateTime.Parse(strDate);
@@ -2591,7 +2665,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                     return date;
 
                 string strTime = timeField.GetAttribute("value");
-                if(strTime.IsEmptyValue())
+                if (strTime.IsEmptyValue())
                     return date;
 
                 var time = DateTime.Parse(strTime);
@@ -2700,7 +2774,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 
         internal BrowserCommandResult<bool> OpenSubGridRecord(string subgridName, int index = 0)
         {
-            return this.Execute(GetOptions($"Open Subgrid record for subgrid { subgridName}"), driver =>
+            return this.Execute(GetOptions($"Open Subgrid record for subgrid {subgridName}"), driver =>
             {
                 //Find the Grid
                 var subGrid = driver.FindElement(By.XPath(AppElements.Xpath[AppReference.Entity.SubGridContents].Replace("[NAME]", subgridName)));
@@ -2721,11 +2795,10 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 
         internal BrowserCommandResult<int> GetSubGridItemsCount(string subgridName)
         {
-            return this.Execute(GetOptions($"Get Subgrid Items Count for subgrid { subgridName}"), driver =>
+            return this.Execute(GetOptions($"Get Subgrid Items Count for subgrid {subgridName}"), driver =>
             {
                 List<GridItem> rows = GetSubGridItems(subgridName);
                 return rows.Count;
-
             });
         }
 
@@ -2804,7 +2877,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             var controlName = control.Name;
             var xpathToContainer = AppElements.Xpath[AppReference.Entity.Header.OptionSetFieldContainer].Replace("[NAME]", controlName);
             return Execute(GetOptions($"Get Header OptionSet Value {controlName}"),
-                    driver => ExecuteInHeaderContainer(driver, xpathToContainer, container => TryGetValue(container, control))
+                driver => ExecuteInHeaderContainer(driver, xpathToContainer, container => TryGetValue(container, control))
             );
         }
 
@@ -2843,7 +2916,6 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                     return "unknown";
 
                 return status.Text;
-
             });
         }
 
@@ -2864,13 +2936,13 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             var controlName = control.Name;
             var xpathToContainer = AppElements.Xpath[AppReference.Entity.Header.LookupFieldContainer].Replace("[NAME]", controlName);
             return Execute(GetOptions($"Set Header LookupItem Value {controlName}"),
-                    driver => ExecuteInHeaderContainer(driver, xpathToContainer,
-                        fieldContainer =>
-            {
-                            TryRemoveLookupValue(driver, fieldContainer, control);
-                            TrySetValue(fieldContainer, control, index);
-                return true;
-                        }));
+                driver => ExecuteInHeaderContainer(driver, xpathToContainer,
+                    fieldContainer =>
+                    {
+                        TryRemoveLookupValue(driver, fieldContainer, control);
+                        TrySetValue(fieldContainer, control, index);
+                        return true;
+                    }));
         }
 
         internal BrowserCommandResult<bool> SetHeaderValue(LookupItem[] controls, int index = 0, bool clearFirst = true)
@@ -2879,15 +2951,15 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             var controlName = control.Name;
             var xpathToContainer = AppElements.Xpath[AppReference.Entity.Header.LookupFieldContainer].Replace("[NAME]", controlName);
             return Execute(GetOptions($"Set Header Activityparty LookupItem Value {controlName}"),
-                    driver => ExecuteInHeaderContainer(driver, xpathToContainer,
-                        container =>
-            {
-                            if (clearFirst)
-                                TryRemoveLookupValue(driver, container, control);
+                driver => ExecuteInHeaderContainer(driver, xpathToContainer,
+                    container =>
+                    {
+                        if (clearFirst)
+                            TryRemoveLookupValue(driver, container, control);
 
-                            TryToSetValue(container, controls, index);
-                return true;
-                        }));
+                        TryToSetValue(container, controls, index);
+                        return true;
+                    }));
         }
 
         internal BrowserCommandResult<bool> SetHeaderValue(OptionSet control)
@@ -2897,9 +2969,9 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             return Execute(GetOptions($"Set Header OptionSet Value {controlName}"),
                 driver => ExecuteInHeaderContainer(driver, xpathToContainer,
                     container =>
-            {
+                    {
                         TrySetValue(container, control);
-                return true;
+                        return true;
                     }));
         }
 
@@ -2926,7 +2998,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 return true;
             });
         }
-        
+
         internal BrowserCommandResult<bool> SetHeaderValue(string field, DateTime value, string formatDate = null, string formatTime = null)
         {
             var control = new DateTimeControl(field)
@@ -2937,23 +3009,27 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             };
             return SetHeaderValue(control);
         }
-       
-        internal BrowserCommandResult<bool> SetHeaderValue(DateTimeControl control)
-        {
-            return Execute(GetOptions($"Set Header Value {control.Name}"), driver =>
-            {
-                if (!driver.HasElement(By.XPath(AppElements.Xpath[AppReference.Entity.Header.Container])))
-                    throw new NotFoundException("Unable to find header on the form");
 
-                return SetValue(driver, control);
-            }); 
+        internal BrowserCommandResult<bool> SetHeaderValue(DateTimeControl control)
+            => Execute(GetOptions($"Set Header Date/Time Value: {control.Name}"), driver => TrySetHeaderValue(driver, control));
+
+        internal BrowserCommandResult<bool> ClearHeaderValue(DateTimeControl control)
+        {
+            var controlName = control.Name;
+            return Execute(GetOptions($"Clear Header Date/Time Value: {controlName}"),
+                driver => TrySetHeaderValue(driver, new DateTimeControl(controlName)));
         }
-        
-        internal BrowserCommandResult<bool> ClearHeaderValue(DateTimeControl control) 
-            => SetHeaderValue(new DateTimeControl(control.Name)); // Passt an empty control
-        
-        internal BrowserCommandResult<bool> ClearValue(DateTimeControl control) 
-            => Execute(GetOptions($"Clear Field: {control.Name}"), driver => SetValue(driver, new DateTimeControl(control.Name))); // Passt an empty control
+
+        private bool TrySetHeaderValue(IWebDriver driver, DateTimeControl control)
+        {
+            var xpathToContainer = AppElements.Xpath[AppReference.Entity.Header.DateTimeFieldContainer].Replace("[NAME]", control.Name);
+            return ExecuteInHeaderContainer(driver, xpathToContainer,
+                container => TrySetValue(driver, container, control));
+        }
+
+        internal BrowserCommandResult<bool> ClearValue(DateTimeControl control)
+            => Execute(GetOptions($"Clear Field: {control.Name}"),
+                driver => TrySetValue(driver, container: driver, control: new DateTimeControl(control.Name))); // Pass an empty control
 
         internal BrowserCommandResult<bool> ClearValue(string fieldName)
         {
@@ -2979,7 +3055,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         private static void TryRemoveLookupValue(IWebDriver driver, IWebElement fieldContainer, LookupItem control, bool removeAll = true)
         {
             var controlName = control.Name;
-                fieldContainer.Hover(driver);
+            fieldContainer.Hover(driver);
 
             var xpathDeleteExistingValues = By.XPath(AppElements.Xpath[AppReference.Entity.LookupFieldDeleteExistingValue].Replace("[NAME]", controlName));
             var existingValues = fieldContainer.FindElements(xpathDeleteExistingValues);
@@ -2987,54 +3063,55 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             var xpathToExpandButton = By.XPath(AppElements.Xpath[AppReference.Entity.LookupFieldExpandCollapseButton].Replace("[NAME]", controlName));
             bool success = fieldContainer.TryFindElement(xpathToExpandButton, out var expandButton);
             if (success)
-                {
+            {
                 expandButton.Click(true);
 
                 var count = existingValues.Count;
                 fieldContainer.WaitUntil(x => x.FindElements(xpathDeleteExistingValues).Count > count);
-                }
-                else
-                {
+            }
+            else
+            {
                 var xpathToHoveExistingValue = By.XPath(AppElements.Xpath[AppReference.Entity.LookupFieldHoverExistingValue].Replace("[NAME]", controlName));
                 var found = fieldContainer.TryFindElement(xpathToHoveExistingValue, out var existingList);
                 if (found)
-                        existingList.SendKeys(Keys.Clear);
-                    }
+                    existingList.SendKeys(Keys.Clear);
+            }
 
             fieldContainer.WaitUntilAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.TextFieldLookupSearchButton].Replace("[NAME]", controlName)));
 
             existingValues = fieldContainer.FindElements(xpathDeleteExistingValues);
-                if (existingValues.Count == 0)
+            if (existingValues.Count == 0)
                 return;
 
-                if (removeAll)
-                {
-                    // Removes all selected items
+            if (removeAll)
+            {
+                // Removes all selected items
 
-                    while (existingValues.Count > 0)
-                    {
+                while (existingValues.Count > 0)
+                {
                     foreach (var v in existingValues)
                         v.Click(true);
 
                     existingValues = fieldContainer.FindElements(xpathDeleteExistingValues);
-                    }
-                return;
                 }
 
-                    // Removes an individual item by value or index
+                return;
+            }
+
+            // Removes an individual item by value or index
             var value = control.Value;
             if (value == null)
                 throw new InvalidOperationException($"No value or index has been provided for the LookupItem {controlName}. Please provide an value or an empty string or an index and try again.");
 
             if (value == string.Empty)
-                    {
+            {
                 var index = control.Index;
                 if (index >= existingValues.Count)
                     throw new InvalidOperationException($"Field '{controlName}' does not contain {index + 1} records. Please provide an index value less than {existingValues.Count}");
 
                 existingValues[index].Click(true);
                 return;
-                    }
+            }
 
             var existingValue = existingValues.FirstOrDefault(v => v.GetAttribute("aria-label").EndsWith(value));
             if (existingValue == null)
@@ -3116,6 +3193,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 {
                     ClearValue(control, false);
                 }
+
                 return true;
             });
         }
@@ -3128,15 +3206,14 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 
             var xpathToFlyout = AppElements.Xpath[AppReference.Entity.Header.Flyout];
             driver.WaitUntilVisible(By.XPath(xpathToFlyout), TimeSpan.FromSeconds(5),
-                d =>
-            {
-                    var flyout = d.FindElement(By.XPath(xpathToFlyout));
+                flyout =>
+                {
                     IWebElement container = flyout.FindElement(By.XPath(xpathToContainer));
                     lookupValue = function(container);
                 });
 
             return lookupValue;
-            }
+        }
 
         internal void TryExpandHeaderFlyout(IWebDriver driver)
         {
@@ -3151,9 +3228,11 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             if (!expanded)
                 headerFlyoutButton.Click(true);
         }
+
         #endregion
 
         #region Lookup 
+
         internal BrowserCommandResult<bool> OpenLookupRecord(int index)
         {
             return this.Execute(GetOptions("Select Lookup Record"), driver =>
@@ -3285,9 +3364,11 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                     // action should take place after it and hence it is ignored.
                     return false;
                 }
+
                 return true;
             });
         }
+
         internal BrowserCommandResult<bool> Delete(int thinkTime = Constants.DefaultThinkTime)
         {
             this.Browser.ThinkTime(thinkTime);
@@ -3295,7 +3376,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             return this.Execute(GetOptions($"Delete Entity"), driver =>
             {
                 var deleteBtn = driver.WaitUntilAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.Delete]),
-    "Delete Button is not available");
+                    "Delete Button is not available");
 
                 deleteBtn?.Click();
                 ConfirmationDialog(true);
@@ -3305,6 +3386,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 return true;
             });
         }
+
         internal BrowserCommandResult<bool> Assign(string userOrTeamToAssign, int thinkTime = Constants.DefaultThinkTime)
         {
             //Click the Assign Button on the Entity Record
@@ -3321,6 +3403,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 return true;
             });
         }
+
         internal BrowserCommandResult<bool> SwitchProcess(string processToSwitchTo, int thinkTime = Constants.DefaultThinkTime)
         {
             this.Browser.ThinkTime(thinkTime);
@@ -3330,14 +3413,15 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 driver.ClickWhenAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.ProcessButton]), TimeSpan.FromSeconds(5));
 
                 driver.ClickWhenAvailable(
-                        By.XPath(AppElements.Xpath[AppReference.Entity.SwitchProcess]),
+                    By.XPath(AppElements.Xpath[AppReference.Entity.SwitchProcess]),
                     TimeSpan.FromSeconds(5),
                     "The Switch Process Button is not available."
-                            );
+                );
 
                 return true;
             });
         }
+
         internal BrowserCommandResult<bool> CloseOpportunity(bool closeAsWon, int thinkTime = Constants.DefaultThinkTime)
         {
             this.Browser.ThinkTime(thinkTime);
@@ -3357,6 +3441,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 return true;
             });
         }
+
         internal BrowserCommandResult<bool> CloseOpportunity(double revenue, DateTime closeDate, string description, int thinkTime = Constants.DefaultThinkTime)
         {
             this.Browser.ThinkTime(thinkTime);
@@ -3370,7 +3455,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 driver.ClickWhenAvailable(By.XPath(AppElements.Xpath[AppReference.Dialogs.CloseOpportunity.Ok]),
                     TimeSpan.FromSeconds(5),
                     "The Close Opportunity dialog is not available."
-                    );
+                );
 
                 return true;
             });
@@ -3415,6 +3500,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                         // It is expected that the components will be destroyed and the next 
                         // action should take place after it and hence it is ignored.
                     }
+
                     return true;
                 }
                 else if (button.FindElements(By.TagName("button")).Any())
@@ -3482,7 +3568,6 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             if (tabList.HasElement(By.XPath(string.Format(xpath, name))))
             {
                 searchScope = tabList;
-
             }
             else if (tabList.TryFindElement(By.XPath(AppElements.Xpath[AppReference.Entity.MoreTabs]), out moreTabsButton))
             {
@@ -3499,7 +3584,6 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             {
                 throw new Exception($"The tab with name: {name} does not exist");
             }
-
         }
 
         /// <summary>
@@ -3524,7 +3608,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                     return true;
                 }
 
-                    throw new InvalidOperationException($"Field: {fieldName} with tagname {expectedTagName} Does not exist");
+                throw new InvalidOperationException($"Field: {fieldName} with tagname {expectedTagName} Does not exist");
             });
         }
 
@@ -3598,6 +3682,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 {
                     throw new InvalidOperationException($"Field: {option.Name} Does not exist");
                 }
+
                 return true;
             });
         }
@@ -3634,6 +3719,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                         fieldContainer.Click(true);
                     }
                 }
+
                 return true;
             });
         }
@@ -3759,7 +3845,6 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         {
             return this.Execute(GetOptions($"Select Stage: {stageName}"), driver =>
             {
-
                 //Find the Business Process Stages
                 var processStages = driver.FindElements(By.XPath(AppElements.Xpath[AppReference.BusinessProcessFlow.NextStage_UCI]));
 
@@ -3794,7 +3879,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                     SelectStage(stageName);
 
                     if (!driver.HasElement(By.XPath("//button[contains(@data-id,'setActiveButton')]")))
-                        throw new NotFoundException($"Unable to find the Set Active button. Please verify the stage name { stageName } is correct.");
+                        throw new NotFoundException($"Unable to find the Set Active button. Please verify the stage name {stageName} is correct.");
 
                     driver.FindElement(By.XPath(AppElements.Xpath[AppReference.BusinessProcessFlow.SetActiveButton])).Click(true);
 
@@ -3846,6 +3931,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         #endregion
 
         #region GlobalSearch
+
         /// <summary>
         /// Searches for the specified criteria in Global Search.
         /// </summary>
@@ -3866,21 +3952,21 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 
                 string reference = null;
                 driver.WaitUntilAvailable(By.XPath(AppElements.Xpath[AppReference.GlobalSearch.Type]),
-                                e =>
-                {
-                                    var searchType = e.GetAttribute("value");
-                                    reference =
-                                        searchType == "0" ? AppReference.GlobalSearch.RelevanceSearchButton :
-                                        searchType == "1" ? AppReference.GlobalSearch.CategorizedSearchButton :
-                                        throw new InvalidOperationException("The Global Search type is not available.");
-                                },
-                                "The Global Search type is not available."
-                                );
+                    e =>
+                    {
+                        var searchType = e.GetAttribute("value");
+                        reference =
+                            searchType == "0" ? AppReference.GlobalSearch.RelevanceSearchButton :
+                            searchType == "1" ? AppReference.GlobalSearch.CategorizedSearchButton :
+                            throw new InvalidOperationException("The Global Search type is not available.");
+                    },
+                    "The Global Search type is not available."
+                );
 
                 IWebElement button = driver.WaitUntilAvailable(By.XPath(AppElements.Xpath[reference]), "The Global Search Button is not available.");
 
-                        input.SendKeys(criteria, true);
-                        button.Click(true);
+                input.SendKeys(criteria, true);
+                button.Click(true);
                 return true;
             });
         }
@@ -3898,20 +3984,19 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             return this.Execute(GetOptions($"Filter With: {entity}"), driver =>
             {
                 driver.WaitUntilVisible(By.XPath(AppElements.Xpath[AppReference.GlobalSearch.Filter]),
-                                        TimeSpan.FromSeconds(10),
-                                        picklist =>
-                                        {
-                                            var options = picklist.FindElements(By.TagName("option"));
-                                            var option = options.FirstOrDefault(x => x.Text == entity);
-                                            if (option == null)
-                                                throw new InvalidOperationException($"Entity '{entity}' does not exist in the Filter options.");
+                    TimeSpan.FromSeconds(10),
+                    picklist =>
+                    {
+                        var options = picklist.FindElements(By.TagName("option"));
+                        var option = options.FirstOrDefault(x => x.Text == entity);
+                        if (option == null)
+                            throw new InvalidOperationException($"Entity '{entity}' does not exist in the Filter options.");
 
-                                            picklist.Click();
-                                            option.Click();
-                                        },
-                                        "Filter With picklist is not available. The timeout period elapsed waiting for the picklist to be available."
-                                        );
-
+                        picklist.Click();
+                        option.Click();
+                    },
+                    "Filter With picklist is not available. The timeout period elapsed waiting for the picklist to be available."
+                );
 
 
                 return true;
@@ -3933,10 +4018,10 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 var xpathToContainer = By.XPath(AppElements.Xpath[AppReference.GlobalSearch.GroupContainer].Replace("[NAME]", filterBy));
                 var xpathToValue = By.XPath(AppElements.Xpath[AppReference.GlobalSearch.FilterValue].Replace("[NAME]", value));
                 driver.WaitUntilVisible(xpathToContainer,
-                                        TimeSpan.FromSeconds(10),
-                                        groupContainer => groupContainer.ClickWhenAvailable(xpathToValue, $"Filter By Value '{value}' does not exist in the Filter options."),
-                                        "Filter With picklist is not available. The timeout period elapsed waiting for the picklist to be available."
-                                        );
+                    TimeSpan.FromSeconds(10),
+                    groupContainer => groupContainer.ClickWhenAvailable(xpathToValue, $"Filter By Value '{value}' does not exist in the Filter options."),
+                    "Filter With picklist is not available. The timeout period elapsed waiting for the picklist to be available."
+                );
                 return true;
             });
         }
@@ -3960,13 +4045,13 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 if (searchType == "1") //Categorized Search
                 {
                     var resultsContainer = driver.WaitUntilVisible(By.XPath(AppElements.Xpath[AppReference.GlobalSearch.Container]),
-                                            Constants.DefaultTimeout,
-                                            "Search Results is not available"
-                                            );
+                        Constants.DefaultTimeout,
+                        "Search Results is not available"
+                    );
 
                     var entityContainer = resultsContainer.WaitUntilAvailable(By.XPath(AppElements.Xpath[AppReference.GlobalSearch.EntityContainer].Replace("[NAME]", entity)),
                         $"Entity {entity} was not found in the results"
-                        );
+                    );
 
                     var records = entityContainer.FindElements(By.XPath(AppElements.Xpath[AppReference.GlobalSearch.Records]));
                     if (records == null || records.Count == 0)
@@ -3984,7 +4069,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                     return true;
                 }
 
-                if (searchType == "0")   //Relevance Search
+                if (searchType == "0") //Relevance Search
                 {
                     var resultsContainer = driver.WaitUntilAvailable(By.XPath(AppElements.Xpath[AppReference.GlobalSearch.RelevanceResultsContainer]));
                     var records = resultsContainer.FindElements(By.XPath(AppElements.Xpath[AppReference.GlobalSearch.RelevanceResults].Replace("[ENTITY]", entity.ToUpper())));
@@ -3992,7 +4077,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                     if (index >= records.Count)
                         throw new InvalidOperationException($"There was less than {index} records in your the search result.");
 
-                        records[index].Click(true);
+                    records[index].Click(true);
                     return true;
                 }
 
@@ -4013,24 +4098,26 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             return this.Execute(GetOptions("Change Search Type"), driver =>
             {
                 driver.WaitUntilVisible(By.XPath(AppElements.Xpath[AppReference.GlobalSearch.Type]),
-                                        Constants.DefaultTimeout,
-                                        select =>
-                                        {
-                                            var options = select.FindElements(By.TagName("option"));
-                                            var option = options.FirstOrDefault(x => x.Text.Trim() == type);
-                                            if (option == null)
-                                                return;
+                    Constants.DefaultTimeout,
+                    select =>
+                    {
+                        var options = select.FindElements(By.TagName("option"));
+                        var option = options.FirstOrDefault(x => x.Text.Trim() == type);
+                        if (option == null)
+                            return;
 
-                                                select.Click(true);
-                                                option.Click(true);
-                                        },
-                                       "Search Results is not available");
+                        select.Click(true);
+                        option.Click(true);
+                    },
+                    "Search Results is not available");
                 return true;
             });
         }
+
         #endregion
 
         #region Dashboard
+
         internal BrowserCommandResult<bool> SelectDashboard(string dashboardName, int thinkTime = Constants.DefaultThinkTime)
         {
             this.Browser.ThinkTime(thinkTime);
@@ -4045,6 +4132,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 return true;
             });
         }
+
         #endregion
 
         #region PerformanceCenter
@@ -4056,13 +4144,13 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             Browser.Driver.WaitForTransaction();
         }
 
-
         #endregion
 
         internal void ThinkTime(int milliseconds)
         {
             Browser.ThinkTime(milliseconds);
         }
+
         internal void Dispose()
         {
             Browser.Dispose();

--- a/Microsoft.Dynamics365.UIAutomation.Browser/Extensions/SeleniumExtensions.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Browser/Extensions/SeleniumExtensions.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Browser
     public static class SeleniumExtensions
     {
         #region Click
-        
+
         public static void Click(this IWebElement element, bool ignoreStaleElementException)
         {
             try
@@ -49,11 +49,11 @@ namespace Microsoft.Dynamics365.UIAutomation.Browser
                 return null;
 
             element.Click();
-            System.Threading.Thread.Sleep((int) timeout.TotalMilliseconds);
+            System.Threading.Thread.Sleep((int)timeout.TotalMilliseconds);
 
             return element;
         }
-        
+
         public static void Hover(this IWebElement element, IWebDriver driver, bool ignoreStaleElementException = true)
         {
             try
@@ -88,16 +88,8 @@ namespace Microsoft.Dynamics365.UIAutomation.Browser
 
         public static void DoubleClick(this IWebDriver driver, By by, bool ignoreStaleElementException = false)
         {
-            try
-            {
-                var element = driver.FindElement(by);
-                driver.DoubleClick(element, ignoreStaleElementException);
-            }
-            catch (StaleElementReferenceException ex)
-            {
-                if (!ignoreStaleElementException)
-                    throw ex;
-            }
+            var element = driver.FindElement(by);
+            driver.DoubleClick(element, ignoreStaleElementException);
         }
 
         #endregion
@@ -144,7 +136,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Browser
             var results = ExecuteScript(driver, $"return JSON.stringify({@object});").ToString();
             var jsSerializer = new JavaScriptSerializer();
 
-            jsSerializer.RegisterConverters(new[] {new DynamicJsonConverter()});
+            jsSerializer.RegisterConverters(new[] { new DynamicJsonConverter() });
 
             var jsonObj = new JavaScriptSerializer().Deserialize<T>(results);
 
@@ -216,7 +208,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Browser
         public static T GetAttribute<T>(this IWebElement element, string attributeName)
         {
             string value = element.GetAttribute(attributeName) ?? string.Empty;
-            return (T) TypeDescriptor.GetConverter(typeof(T)).ConvertFromString(value);
+            return (T)TypeDescriptor.GetConverter(typeof(T)).ConvertFromString(value);
         }
 
         public static string GetAuthority(this IWebDriver driver)
@@ -254,15 +246,20 @@ namespace Microsoft.Dynamics365.UIAutomation.Browser
                 wait.Until(ExpectedConditions.AlertIsPresent());
                 return true;
             }
-            catch (NoSuchElementException){ }
+            catch (NoSuchElementException) { }
             catch (WebDriverTimeoutException) { }
             return false;
         }
 
-        public static IWebDriver LastWindow(this IWebDriver driver) 
+        public static IWebDriver LastWindow(this IWebDriver driver)
             => driver.SwitchTo().Window(driver.WindowHandles.Last());
 
-        /// <summary>Clears the focus from all elements.</summary>
+        
+        /// <summary>
+        /// Clears the focus from all elements.
+        /// TODO: this implementation of the ClearFocus is clicking somewhere on the body, that may happen in some unwanted point, changing the results of the test.
+        /// Clicking on the label of the current control may have a better result.
+        /// </summary>
         /// <param name="driver">The driver.</param>
         public static void ClearFocus(this IWebDriver driver)
         {
@@ -285,7 +282,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Browser
                 {
                     try
                     {
-                        state = ((IJavaScriptExecutor) driver).ExecuteScript(@"return document.readyState").ToString();
+                        state = ((IJavaScriptExecutor)driver).ExecuteScript(@"return document.readyState").ToString();
                     }
                     catch (InvalidOperationException)
                     {
@@ -320,7 +317,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Browser
                     driver.SwitchTo().Window(driver.WindowHandles[0]);
                 }
 
-                state = ((IJavaScriptExecutor) driver).ExecuteScript(@"return document.readyState").ToString();
+                state = ((IJavaScriptExecutor)driver).ExecuteScript(@"return document.readyState").ToString();
                 if (!(state.Equals("complete", StringComparison.InvariantCultureIgnoreCase) || state.Equals("loaded", StringComparison.InvariantCultureIgnoreCase)))
                     throw;
             }
@@ -336,7 +333,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Browser
             wait.IgnoreExceptionTypes(typeof(TimeoutException), typeof(NullReferenceException));
             try
             {
-                state = wait.Until(d => (bool) driver.ExecuteScript("return window.UCWorkBlockTracker.isAppIdle()")); // Check to see if UCI is idle
+                state = wait.Until(d => (bool)driver.ExecuteScript("return window.UCWorkBlockTracker.isAppIdle()")); // Check to see if UCI is idle
             }
             catch (Exception)
             {
@@ -426,23 +423,23 @@ namespace Microsoft.Dynamics365.UIAutomation.Browser
             element = success ? elements[0] : null;
             return success;
         }
-        
-        
-        public static IWebElement WaitUntilAvailable(this ISearchContext driver, By by, string exceptionMessage) 
+
+
+        public static IWebElement WaitUntilAvailable(this ISearchContext driver, By by, string exceptionMessage)
             => WaitUntilAvailable(driver, by, null, null, exceptionMessage);
 
-        public static IWebElement WaitUntilAvailable(this ISearchContext driver, By by, Action<IWebElement> successCallback, string exceptionMessage) 
+        public static IWebElement WaitUntilAvailable(this ISearchContext driver, By by, Action<IWebElement> successCallback, string exceptionMessage)
             => WaitUntilAvailable(driver, by, null, successCallback, exceptionMessage);
 
-        public static IWebElement WaitUntilAvailable(this ISearchContext driver, By by, TimeSpan timeout, string exceptionMessage) 
+        public static IWebElement WaitUntilAvailable(this ISearchContext driver, By by, TimeSpan timeout, string exceptionMessage)
             => WaitUntilAvailable(driver, by, timeout, null, exceptionMessage);
 
-        public static IWebElement WaitUntilAvailable(this ISearchContext driver,By by, 
-            TimeSpan? timeout, 
-            Action<IWebElement> successCallback, 
+        public static IWebElement WaitUntilAvailable(this ISearchContext driver, By by,
+            TimeSpan? timeout,
+            Action<IWebElement> successCallback,
             string exceptionMessage)
         {
-            if (string.IsNullOrWhiteSpace(exceptionMessage)) 
+            if (string.IsNullOrWhiteSpace(exceptionMessage))
                 exceptionMessage = $"Unable to find any element by: {by}";
             return WaitUntilAvailable(driver, by, timeout, successCallback, () => throw new InvalidOperationException(exceptionMessage));
         }
@@ -458,21 +455,21 @@ namespace Microsoft.Dynamics365.UIAutomation.Browser
             );
         }
 
-        public static IWebElement WaitUntilVisible(this ISearchContext driver, By by, string exceptionMessage) 
+        public static IWebElement WaitUntilVisible(this ISearchContext driver, By by, string exceptionMessage)
             => WaitUntilVisible(driver, by, null, null, exceptionMessage);
-        
-        public static IWebElement WaitUntilVisible(this ISearchContext driver, By by, Action<IWebElement> successCallback, string exceptionMessage) 
+
+        public static IWebElement WaitUntilVisible(this ISearchContext driver, By by, Action<IWebElement> successCallback, string exceptionMessage)
             => WaitUntilVisible(driver, by, null, successCallback, exceptionMessage);
 
-        public static IWebElement WaitUntilVisible(this ISearchContext driver, By by, TimeSpan timeout, string exceptionMessage) 
+        public static IWebElement WaitUntilVisible(this ISearchContext driver, By by, TimeSpan timeout, string exceptionMessage)
             => WaitUntilVisible(driver, by, timeout, null, exceptionMessage);
 
-        public static IWebElement WaitUntilVisible(this ISearchContext driver, By by, 
-            TimeSpan? timeout, 
-            Action<IWebElement> successCallback, 
+        public static IWebElement WaitUntilVisible(this ISearchContext driver, By by,
+            TimeSpan? timeout,
+            Action<IWebElement> successCallback,
             string exceptionMessage)
         {
-            if (string.IsNullOrWhiteSpace(exceptionMessage)) 
+            if (string.IsNullOrWhiteSpace(exceptionMessage))
                 exceptionMessage = $"Unable to find any visible element by: {by}";
             return WaitUntilVisible(driver, by, timeout, successCallback, () => throw new InvalidOperationException(exceptionMessage));
         }
@@ -486,18 +483,18 @@ namespace Microsoft.Dynamics365.UIAutomation.Browser
         }
 
 
-        public static IWebElement WaitUntilClickable(this ISearchContext driver, By by, string exceptionMessage) 
+        public static IWebElement WaitUntilClickable(this ISearchContext driver, By by, string exceptionMessage)
             => WaitUntilClickable(driver, by, null, null, exceptionMessage);
-        
-        public static IWebElement WaitUntilClickable(this ISearchContext driver, By by, Action<IWebElement> successCallback, string exceptionMessage) 
+
+        public static IWebElement WaitUntilClickable(this ISearchContext driver, By by, Action<IWebElement> successCallback, string exceptionMessage)
             => WaitUntilClickable(driver, by, null, successCallback, exceptionMessage);
 
-        public static IWebElement WaitUntilClickable(this ISearchContext driver, By by, TimeSpan timeout, string exceptionMessage) 
+        public static IWebElement WaitUntilClickable(this ISearchContext driver, By by, TimeSpan timeout, string exceptionMessage)
             => WaitUntilClickable(driver, by, timeout, null, exceptionMessage);
 
         public static IWebElement WaitUntilClickable(this ISearchContext driver, By by, TimeSpan? timeout, Action<IWebElement> successCallback, string exceptionMessage)
         {
-            if (string.IsNullOrWhiteSpace(exceptionMessage)) 
+            if (string.IsNullOrWhiteSpace(exceptionMessage))
                 exceptionMessage = $"Unable to find any clickable element by: {by}";
             return WaitUntilClickable(driver, by, timeout, successCallback, () => throw new InvalidOperationException(exceptionMessage));
         }
@@ -517,7 +514,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Browser
             TimeSpan? timeout = null,
             Action successCallback = null, Action failureCallback = null)
         {
-            var wait = new DefaultWait<ISearchContext>(driver) {Timeout = timeout ?? Constants.DefaultTimeout};
+            var wait = new DefaultWait<ISearchContext>(driver) { Timeout = timeout ?? Constants.DefaultTimeout };
             wait.IgnoreExceptionTypes(typeof(NoSuchElementException), typeof(StaleElementReferenceException));
 
             bool success = false;
@@ -525,7 +522,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Browser
             {
                 success = wait.Until(d => predicate(d));
             }
-            catch (WebDriverTimeoutException){}
+            catch (WebDriverTimeoutException) { }
 
             if (success)
                 successCallback?.Invoke();
@@ -539,8 +536,10 @@ namespace Microsoft.Dynamics365.UIAutomation.Browser
             TimeSpan? timeout = null,
             Action<IWebElement> successCallback = null, Action failureCallback = null)
         {
-            var wait = new DefaultWait<ISearchContext>(driver) {Timeout = timeout ?? Constants.DefaultTimeout};
-
+            var wait = new DefaultWait<ISearchContext>(driver)
+            {
+                Timeout = timeout ?? Constants.DefaultTimeout
+            };
             wait.IgnoreExceptionTypes(typeof(NoSuchElementException), typeof(StaleElementReferenceException));
 
             bool success = false;

--- a/Microsoft.Dynamics365.UIAutomation.Sample/UCI/Create/CreateActivity.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Sample/UCI/Create/CreateActivity.cs
@@ -105,15 +105,15 @@ namespace Microsoft.Dynamics365.UIAutomation.Sample.UCI
                 
                 DateTime expectedDate = DateTime.Today.AddDays(1).AddHours(10);
              
-                //xrmApp.Entity.SetHeaderValue("scheduledstart",  expectedDate);
-                var start = new DateTimeControl("scheduledstart") { Value =  expectedDate};
-                xrmApp.Entity.SetHeaderValue(start);
+                //xrmApp.Entity.SetHeaderValue("scheduledend",  expectedDate);
+                var end = new DateTimeControl("scheduledend") { Value =  expectedDate};
+                xrmApp.Entity.SetHeaderValue(end);
 
-                DateTime? date = xrmApp.Entity.GetHeaderValue(start);
+                DateTime? date = xrmApp.Entity.GetHeaderValue(end);
                 Assert.AreEqual(expectedDate, date);
                 
-                xrmApp.Entity.ClearHeaderValue(start);
-                date = xrmApp.Entity.GetHeaderValue(start);
+                xrmApp.Entity.ClearHeaderValue(end);
+                date = xrmApp.Entity.GetHeaderValue(end);
                 Assert.AreEqual(null, date);
             }
         }

--- a/Microsoft.Dynamics365.UIAutomation.Sample/UCI/Create/CreateActivity.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Sample/UCI/Create/CreateActivity.cs
@@ -104,14 +104,19 @@ namespace Microsoft.Dynamics365.UIAutomation.Sample.UCI
                 xrmApp.Entity.SetValue("subject", "Appointment "+ TestSettings.GetRandomString(5,10));
                 
                 DateTime expectedDate = DateTime.Today.AddDays(1).AddHours(10);
+                DateTime expectedEndDate = expectedDate.AddHours(2);
+
+                var start = new DateTimeControl("scheduledstart") { Value =  expectedDate};
+                xrmApp.Entity.SetValue(start);
              
-                //xrmApp.Entity.SetHeaderValue("scheduledend",  expectedDate);
-                var end = new DateTimeControl("scheduledend") { Value =  expectedDate};
+                var end = new DateTimeControl("scheduledend") { Value =  expectedEndDate};
                 xrmApp.Entity.SetHeaderValue(end);
 
                 DateTime? date = xrmApp.Entity.GetHeaderValue(end);
-                Assert.AreEqual(expectedDate, date);
+                Assert.AreEqual(expectedEndDate, date);
                 
+                xrmApp.Entity.ClearValue(start);
+
                 xrmApp.Entity.ClearHeaderValue(end);
                 date = xrmApp.Entity.GetHeaderValue(end);
                 Assert.AreEqual(null, date);

--- a/Microsoft.Dynamics365.UIAutomation.Sample/UCI/Read/OpenAccount.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Sample/UCI/Read/OpenAccount.cs
@@ -8,119 +8,73 @@ using System;
 namespace Microsoft.Dynamics365.UIAutomation.Sample.UCI
 {
     [TestClass]
-    public class OpenAccountUCI: TestsBase
+    public class OpenAccountUCI : TestsBase
     {
+        [TestInitialize]
+        public override void InitTest() => base.InitTest();
+
+        [TestCleanup]
+        public override void FinishTest() => base.FinishTest();
+
+        public override void NavigateToHomePage() => _xrmApp.Navigation.OpenSubArea("Sales", "Accounts");
+
         [TestMethod]
         public void UCITestOpenActiveAccount()
         {
-            var client = new WebClient(TestSettings.Options);
-            using (var xrmApp = new XrmApp(client))
-            {
-                xrmApp.OnlineLogin.Login(_xrmUri, _username, _password, _mfaSecrectKey);
+            _xrmApp.Grid.Search("Adventure");
 
-                xrmApp.Navigation.OpenApp(UCIAppName.Sales);
-                xrmApp.Navigation.OpenApp("Sales");
+            _xrmApp.Grid.OpenRecord(0);
+            
+            _xrmApp.ThinkTime(1000);
 
-                xrmApp.Navigation.OpenApp(UCIAppName.Sales);
-                xrmApp.Navigation.OpenApp(UCIAppName.Sales);
-
-                xrmApp.Navigation.OpenSubArea("Sales", "Accounts");
-                
-                xrmApp.Grid.Search("Adventure");
-
-                xrmApp.Grid.OpenRecord(0);
-
-                xrmApp.ThinkTime(3000);
-
-            }
+            string value = _xrmApp.Entity.GetValue("name");
+            Assert.IsTrue(value.StartsWith("Adventure"));
         }
 
         [TestMethod]
         public void UCITestGetActiveGridItems()
         {
-            var client = new WebClient(TestSettings.Options);
-            using (var xrmApp = new XrmApp(client))
-            {
-                xrmApp.OnlineLogin.Login(_xrmUri, _username, _password, _mfaSecrectKey);
+            _xrmApp.Grid.GetGridItems();
 
-                xrmApp.Navigation.OpenApp(UCIAppName.Sales);
+            _xrmApp.Grid.Sort("Account Name");
 
-                xrmApp.Navigation.OpenSubArea("Sales", "Accounts");
-
-                xrmApp.Grid.GetGridItems();
-
-                xrmApp.Grid.Sort("Account Name");
-
-                xrmApp.ThinkTime(3000);
-            }
+            _xrmApp.ThinkTime(3000);
         }
 
         [TestMethod]
         public void UCITestOpenTabDetails()
         {
-            var client = new WebClient(TestSettings.Options);
-            using (var xrmApp = new XrmApp(client))
-            {
-                xrmApp.OnlineLogin.Login(_xrmUri, _username, _password, _mfaSecrectKey);
+            _xrmApp.Grid.SwitchView("All Accounts");
 
-                xrmApp.Navigation.OpenApp(UCIAppName.Sales);
+            _xrmApp.Grid.OpenRecord(0);
 
-                xrmApp.Navigation.OpenSubArea("Sales", "Accounts");
+            _xrmApp.ThinkTime(3000);
 
-                xrmApp.Grid.SwitchView("All Accounts");
+            _xrmApp.Entity.SelectTab("Details");
 
-                xrmApp.Grid.OpenRecord(0);
-
-                xrmApp.ThinkTime(3000);
-
-                xrmApp.Entity.SelectTab("Details");
-
-                xrmApp.Entity.SelectTab("Related","Contacts");
-
-                xrmApp.ThinkTime(3000);
-            }
+            _xrmApp.Entity.SelectTab("Related", "Contacts");
+            
+            _xrmApp.ThinkTime(3000);
         }
 
         [TestMethod]
         public void UCITestGetObjectId()
         {
-            var client = new WebClient(TestSettings.Options);
+            _xrmApp.Grid.OpenRecord(0);
 
-            using (var xrmApp = new XrmApp(client))
-            {
-                xrmApp.OnlineLogin.Login(_xrmUri, _username, _password, _mfaSecrectKey);
-
-                xrmApp.Navigation.OpenApp(UCIAppName.Sales);
-
-                xrmApp.Navigation.OpenSubArea("Sales", "Accounts");
-
-                xrmApp.Grid.OpenRecord(0);
-
-                Guid objectId = xrmApp.Entity.GetObjectId();
-
-                xrmApp.ThinkTime(3000);
-            }
+            Guid objectId = _xrmApp.Entity.GetObjectId();
+            Assert.AreNotEqual(Guid.Empty, objectId);
+            _xrmApp.ThinkTime(3000);
         }
 
         [TestMethod]
         public void UCITestOpenSubGridRecord()
         {
-            var client = new WebClient(TestSettings.Options);
+            _xrmApp.Grid.OpenRecord(0);
 
-            using (var xrmApp = new XrmApp(client))
-            {
-                xrmApp.OnlineLogin.Login(_xrmUri, _username, _password, _mfaSecrectKey);
+            _xrmApp.Entity.GetSubGridItems("CONTACTS");
 
-                xrmApp.Navigation.OpenApp(UCIAppName.Sales);
-
-                xrmApp.Navigation.OpenSubArea("Sales", "Accounts");
-
-                xrmApp.Grid.OpenRecord(0);
-
-                xrmApp.Entity.GetSubGridItems("CONTACTS");
-
-                xrmApp.ThinkTime(3000);
-            }
+            _xrmApp.ThinkTime(3000);
         }
     }
 }


### PR DESCRIPTION
### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (updates to documentation, formatting, etc.)

### Description
The values of the fields should get in the context where the control is.
See #719 for LookupItem this PR fix the same logic but for the DateTimeControl.

DONE: Get/SetHeaderValue for LookupItem / LookupItem[] / OptionSet
TODO: Get/SetHeaderValue for string / MultiValueOptionSet / BooleanItem

### Issues addressed
Related to #719 

### All submissions:

- [x] My code follows the code style of this project.
- [x] Do existing samples that are effected by this change still run?
- [x] I have added samples for new functionality. 
- [x] I raise detailed error messages when possible.
- [x] My code does not rely on labels that have the option to be hidden.

### Which browsers was this tested on?
<!--- Should be tested on Chrome, Firefox, and IE. -->
- [x] Chrome
- [ ] Firefox
- [ ] IE
- [ ] Edge
