### PR TITLE
Bug Fix: Returning Lookup Values in Lower Case

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -1904,13 +1904,13 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 if (clearFirst)
                     TryRemoveLookupValue(driver, fieldContainer, control);
 
-                TryToSetValue(fieldContainer, controls);
+                TryToSetValue(driver, fieldContainer, controls);
 
                 return true;
             });
         }
 
-        private void TryToSetValue(ISearchContext fieldContainer, LookupItem[] controls)
+        private void TryToSetValue(IWebDriver driver, ISearchContext fieldContainer, LookupItem[] controls)
         {
             IWebElement input;
             bool found = fieldContainer.TryFindElement(By.TagName("input"), out input);
@@ -1925,6 +1925,8 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                     else
                     {
                         input.SendKeys(value, true);
+                        driver.WaitForTransaction();
+                        ThinkTime(3.Seconds());
                         input.SendKeys(Keys.Tab);
                         input.SendKeys(Keys.Enter);
                     }
@@ -2434,7 +2436,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             {
                 if (existingValues.Count > 0)
                 {
-                    string[] lookupValues = existingValues.Select(v => v.GetAttribute("innerText").ToLowerString()).ToArray(); //IE can return line breaks
+                    string[] lookupValues = existingValues.Select(v => v.GetAttribute("innerText").TrimSpecialCharacters()).ToArray(); //IE can return line breaks
                     return lookupValues;
                 }
 
@@ -2891,7 +2893,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                         if (clearFirst)
                             TryRemoveLookupValue(driver, container, control);
 
-                        TryToSetValue(container, controls);
+                        TryToSetValue(driver, container, controls);
                         return true;
                     }));
         }

--- a/Microsoft.Dynamics365.UIAutomation.Browser/Extensions/StringExtensions.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Browser/Extensions/StringExtensions.cs
@@ -37,7 +37,10 @@ namespace Microsoft.Dynamics365.UIAutomation.Browser
                 Marshal.ZeroFreeGlobalAllocUnicode(unmanagedString);
             }
         }
-        public static string ToLowerString(this string value)
+        public static string ToLowerString(this string value) 
+            => value?.TrimSpecialCharacters().ToLower();
+
+        public static string TrimSpecialCharacters(this string value)
         { 
             char[] trimCharacters = {
                 '\r', 
@@ -50,13 +53,15 @@ namespace Microsoft.Dynamics365.UIAutomation.Browser
                 (char) 59902, //
             };
 
-            return value?.Trim()
-                        .Trim(trimCharacters)
-                        .Replace("\r", string.Empty)
-                        .Replace("\n", string.Empty)
-                        .Replace(Environment.NewLine, string.Empty)
-                        .ToLower();
+            var result = value?.Trim()
+                .Trim(trimCharacters)
+                .Replace("\r", string.Empty)
+                .Replace("\n", string.Empty)
+                .Replace(Environment.NewLine, string.Empty);
+
+            return result;
         }
+
         public static bool Contains(this string source, string value, StringComparison compare)
         {
             return source.IndexOf(value, compare) >= 0;

--- a/Microsoft.Dynamics365.UIAutomation.Sample/UCI/SetValue.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Sample/UCI/SetValue.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Sample.UCI
                 xrmApp.ThinkTime(500);
 
                 xrmApp.Entity.SetValue(new LookupItem[] {
-                    new LookupItem { Name = "to", Value = "Adeventure Works", Index = 0 },
+                    new LookupItem { Name = "to", Value = "Adventure Works", Index = 0 },
                     new LookupItem { Name = "to", Value = "", Index = 0 } });
                 xrmApp.ThinkTime(500);
 
@@ -100,6 +100,38 @@ namespace Microsoft.Dynamics365.UIAutomation.Sample.UCI
                 xrmApp.ThinkTime(500);
 
                 xrmApp.Entity.Save();
+            }
+        }
+
+        [TestMethod]
+        public void UCITestActivityPartySetValue_CaseSensitive()
+        {
+            var client = new WebClient(TestSettings.Options);
+            using (var xrmApp = new XrmApp(client))
+            {
+                xrmApp.OnlineLogin.Login(_xrmUri, _username, _password, _mfaSecrectKey);
+
+                xrmApp.Navigation.OpenApp(UCIAppName.Sales);
+
+                xrmApp.Navigation.OpenSubArea("Sales", "Activities");
+
+                xrmApp.Grid.SwitchView("All Phone Calls");
+                xrmApp.ThinkTime(500);
+
+                xrmApp.Grid.OpenRecord(0);
+                xrmApp.ThinkTime(500);
+
+                xrmApp.Entity.SetValue(new [] {
+                    new LookupItem { Name = "to", Value = "Adventure Works", Index = 0 },
+                    new LookupItem { Name = "to", Value = "Nana Bule", Index = 0 } });
+                xrmApp.ThinkTime(500);
+
+                string toValue = xrmApp.Entity.GetValue(new LookupItem { Name = "to" });
+                Assert.IsTrue(toValue.Contains("Adventure Works"));
+                Assert.IsFalse(toValue.Contains("adventure works"));
+
+                Assert.IsTrue(toValue.Contains("Nana Bule"));
+                Assert.IsFalse(toValue.Contains("nana bule"));
             }
         }
 


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (updates to documentation, formatting, etc.)

### Description
Fix GetValue from Lookup is return the values in Lower Case.
See  [this ](https://github.com/microsoft/EasyRepro/issues/756#issuecomment-588261505) and [this comment](https://github.com/microsoft/EasyRepro/pull/764#issuecomment-588260516) from @thathi.

Add 3 secs waiting time after typing each value in SetValue for Multi-Values Lookup.
Fix 2 Unit Tests.

### Issues addressed
Minor Bugs

### All submissions:
- [x] My code follows the code style of this project.
- [x] Do existing samples that are effected by this change still run?
- [x] I have added samples for new functionality. 
- [x] I raise detailed error messages when possible.
- [x] My code does not rely on labels that have the option to be hidden.

### Which browsers was this tested on?
- [x] Chrome
- [ ] Firefox
- [ ] IE
- [ ] Edge
