### PR TITLE
Fix #770: Add Wait before redirect in Initialize UCI Modes (fix for Edge)

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -44,6 +44,8 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         {
             return this.Execute(GetOptions("Initialize Unified Interface Modes"), driver =>
             {
+                driver.WaitForPageToLoad();
+
                 var uri = driver.Url;
                 var queryParams = "&flags=easyreproautomation=true";
 


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (updates to documentation, formatting, etc.)

### Description
 Navigation is being redirected to the wrong Url. Add WaitForPageToLoad in InitializeModes.

### Issues addressed
Fix #770 

### All submissions:
- [x] My code follows the code style of this project.
- [x] Do existing samples that are effected by this change still run?
- [x] I have added samples for new functionality. 
- [x] I raise detailed error messages when possible.
- [x] My code does not rely on labels that have the option to be hidden.

### Which browsers was this tested on?
<!--- Should be tested on Chrome, Firefox, and IE. -->
- [x] Chrome
- [ ] Firefox
- [ ] IE
- [x] Edge
