### PR TITLE
Enable Traces by default in Samples Project (related to #775)

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Browser/Logs/StringFormater.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Browser/Logs/StringFormater.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Microsoft.Dynamics365.UIAutomation.Browser.Logs
+{
+    public static class StringFormater
+    {
+        /// <summary>
+        /// Return the object as string formatted to be printed in plugin trace or any other log
+        /// </summary>
+        public static string Format(this object value, string format = null)
+        {
+            if (value == null)
+                return "null";
+
+            switch (value)
+            {
+                case string s: return s;
+                case bool b: return b ? "true" : "false";
+                case double d: return d.ToString(format ?? "N");
+                case decimal @decimal: return @decimal.ToString(format ?? "N");
+                case DateTime time: return time.ToString(format ?? "yyyy-MM-dd HH:mm:ss");
+                case Enum enm: return enm.ToString(format ?? "F");
+                default:
+                    return value.ToString();
+            }
+        }
+
+        public static string Format<T>(this T[] array, string separator = ", ")
+        {
+            IEnumerable<string> formated = array.Select(item => Format(item));
+            string joined = string.Join(separator, formated);
+
+            int count = array.Length;
+            string itemType = typeof(T).Name;
+
+            var result = separator.Contains(Environment.NewLine)
+                ? $"Collection: {{{separator}Count: {count}{separator}Items ({itemType}):{separator}{joined}{separator}}}"
+                : $"Collection: {{ Count: {count}{separator}Items ({itemType}): {joined} }}";
+            return result;
+        }
+        
+        public static string Format(this Exception input)
+        {
+            if (input == null)
+                return "null";
+
+            StringBuilder sb = new StringBuilder();
+
+            sb.AppendLine(input.ToString());
+            input = input.InnerException;
+            int deep = 1;
+            while (input != null)
+            {
+                sb.AppendLine($"--- InnerException (deep:{deep++}) ---");
+                sb.AppendLine(input.ToString());
+                input = input.InnerException;
+            }
+
+            return sb.ToString();
+        }
+       
+        public static string FormatCollection<T>(this IEnumerable<T> collection, string separator = ", ")
+        {
+            if (collection == null)
+                return "null";
+
+            var array = collection as T[] ?? collection.ToArray();
+
+            var result = Format(array, separator);
+            return result;
+        }
+    }
+}

--- a/Microsoft.Dynamics365.UIAutomation.Browser/Logs/TracingService.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Browser/Logs/TracingService.cs
@@ -1,0 +1,120 @@
+﻿using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+
+namespace Microsoft.Dynamics365.UIAutomation.Browser.Logs
+{
+    public class TracingService
+    {
+        private readonly TraceSource _trace;
+        private readonly string _loggerName;
+
+        public TracingService(Type type, string traceSource)
+            : this(type.FullName, traceSource) { }
+
+        public TracingService(string loggerName, string traceSource) 
+        {
+            _loggerName = loggerName ?? "<undefined>";
+            _trace = new TraceSource(traceSource);
+        }
+
+        /// <summary>
+        /// Log Message to Trace, include Caller Method Name (safe if trace is null)
+        /// </summary>
+        public void Log(TraceEventType eventType, object message = null, int stackTraceIndex = 1)
+        {
+            try
+            {
+                var stackTrace = new StackTrace();
+                var method = stackTrace.GetFrame(stackTraceIndex)?.GetMethod()?.Name;
+                Write(eventType, $"{method}: {message.Format()}");
+            }
+            catch
+            {
+                // ignored
+            }
+        }
+
+        /// <summary>
+        /// Log Message to Trace, include Caller Method Name (safe if trace is null)
+        /// </summary>
+        public void Log(TraceEventType eventType, string message, params object[] arguments)
+        {
+            try
+            {
+                var stackTrace = new StackTrace();
+                var method = stackTrace.GetFrame(1)?.GetMethod()?.Name;
+                if (arguments == null)
+                    message = string.Format(message, "null");
+                else
+                {
+                    arguments = arguments.Select(a => (object)a.Format()).ToArray();
+                    message = string.Format(message, arguments);
+                }
+                Write(eventType, $"{method}: {message}");
+            }
+            catch
+            {
+                // ignored
+            }
+        }
+
+        // <summary>
+        /// Log Message to Trace, include Caller Method Name (safe if trace is null)
+        /// </summary>
+        public void Log(string message, params object[] arguments)
+        {
+            try
+            {
+                var stackTrace = new StackTrace();
+                var method = stackTrace.GetFrame(1)?.GetMethod()?.Name;
+                if (arguments == null)
+                    message = string.Format(message, "null");
+                else
+                {
+                    arguments = arguments.Select(a => (object)a.Format()).ToArray();
+                    message = string.Format(message, arguments);
+                }
+                Write(TraceEventType.Information, $"{method}: {message}");
+            }
+            catch
+            {
+                // ignored
+            }
+        }
+
+
+        /// <summary>
+        /// Log Message to Trace, include Caller Method Name (safe if trace is null)
+        /// </summary>
+        public void Log(TraceEventType eventType, string message, object argument)
+        {
+            try
+            {
+                var stackTrace = new StackTrace();
+                var method = stackTrace.GetFrame(1)?.GetMethod()?.Name;
+                Write(eventType, $"{method}: {message}{argument.Format()}");
+            }
+            catch
+            {
+                // ignored
+            }
+        }
+        
+        protected void Write(TraceEventType eventType, string message)
+        {
+            var date = DateTime.Now.ToString("yyyy'-'MM'-'dd' 'HH':'mm':'ss'.'fffffff");
+            try
+            {
+                var threadId = Thread.CurrentThread.ManagedThreadId;
+                var finalMessage = $"[{threadId, 4}] [{date}] [{_loggerName}] - {message}";
+                _trace.TraceEvent(eventType, 0, finalMessage);
+            }
+            catch
+            {
+                // ignored : Trace should never throw an exception
+            }
+        }
+    }
+}

--- a/Microsoft.Dynamics365.UIAutomation.Browser/Logs/TracingService.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Browser/Logs/TracingService.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Browser.Logs
         private readonly string _loggerName;
 
         public TracingService(Type type, string traceSource)
-            : this(type.FullName, traceSource) { }
+            : this(type.Name, traceSource) { }
 
         public TracingService(string loggerName, string traceSource) 
         {
@@ -30,9 +30,9 @@ namespace Microsoft.Dynamics365.UIAutomation.Browser.Logs
                 var method = stackTrace.GetFrame(stackTraceIndex)?.GetMethod()?.Name;
                 Write(eventType, $"{method}: {message.Format()}");
             }
-            catch
+            catch(Exception ex)
             {
-                // ignored
+                TraceFail(ex, nameof(Log));
             }
         }
 
@@ -54,13 +54,13 @@ namespace Microsoft.Dynamics365.UIAutomation.Browser.Logs
                 }
                 Write(eventType, $"{method}: {message}");
             }
-            catch
+            catch(Exception ex)
             {
-                // ignored
+                TraceFail(ex, nameof(Log));
             }
         }
 
-        // <summary>
+        /// <summary>
         /// Log Message to Trace, include Caller Method Name (safe if trace is null)
         /// </summary>
         public void Log(string message, params object[] arguments)
@@ -78,9 +78,9 @@ namespace Microsoft.Dynamics365.UIAutomation.Browser.Logs
                 }
                 Write(TraceEventType.Information, $"{method}: {message}");
             }
-            catch
+            catch(Exception ex)
             {
-                // ignored
+                TraceFail(ex, nameof(Log));
             }
         }
 
@@ -96,9 +96,9 @@ namespace Microsoft.Dynamics365.UIAutomation.Browser.Logs
                 var method = stackTrace.GetFrame(1)?.GetMethod()?.Name;
                 Write(eventType, $"{method}: {message}{argument.Format()}");
             }
-            catch
+            catch(Exception ex)
             {
-                // ignored
+                TraceFail(ex, nameof(Log));
             }
         }
         
@@ -108,13 +108,22 @@ namespace Microsoft.Dynamics365.UIAutomation.Browser.Logs
             try
             {
                 var threadId = Thread.CurrentThread.ManagedThreadId;
-                var finalMessage = $"[{threadId, 4}] [{date}] [{_loggerName}] - {message}";
+                var finalMessage = $"[{threadId, 5}] [{date}] [{_loggerName}] - {message}";
                 _trace.TraceEvent(eventType, 0, finalMessage);
             }
-            catch
+            catch(Exception ex)
             {
-                // ignored : Trace should never throw an exception
+                TraceFail(ex, nameof(Write));
             }
+        }
+
+        private static void TraceFail(Exception ex, string method)
+        {
+            var message = $"An error occur in {nameof(TracingService)}.{method}: {ex}";
+          
+            Trace.TraceError($"Trace Error => {message}");
+            // ReSharper disable once LocalizableElement
+            Console.WriteLine($"Console Log => {message}");
         }
     }
 }

--- a/Microsoft.Dynamics365.UIAutomation.Browser/Microsoft.Dynamics365.UIAutomation.Browser.csproj
+++ b/Microsoft.Dynamics365.UIAutomation.Browser/Microsoft.Dynamics365.UIAutomation.Browser.csproj
@@ -81,9 +81,11 @@
     <Compile Include="Extensions\RelativePositions.cs" />
     <Compile Include="Extensions\SeleniumExtensions.cs" />
     <Compile Include="Extensions\StringExtensions.cs" />
+    <Compile Include="Logs\StringFormater.cs" />
     <Compile Include="Extensions\TimeExtensions.cs" />
     <Compile Include="ICommandResult.cs" />
     <Compile Include="InteractiveBrowser.cs" />
+    <Compile Include="Logs\TracingService.cs" />
     <Compile Include="NavigationOperation.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\Resources.Designer.cs">

--- a/Microsoft.Dynamics365.UIAutomation.Sample/ConsoleTraceListener.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Sample/ConsoleTraceListener.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+
+namespace Microsoft.Dynamics365.UIAutomation.Sample
+{
+    // credit:_ Arseni Mourzenko - https://stackoverflow.com/users/240613/arseni-mourzenko
+    // Why are messages sent to trace source missing from all but the first unit test?
+    // https://stackoverflow.com/questions/36327531/why-are-messages-sent-to-trace-source-missing-from-all-but-the-first-unit-test
+    public class ConsoleTraceListener : TextWriterTraceListener
+    {
+        public ConsoleTraceListener() : base(new ConsoleTextWriter()) { }
+
+        public override void Close() { }
+    }
+
+    public class ConsoleTextWriter : TextWriter
+    {
+        public override Encoding Encoding => Console.Out.Encoding;
+
+        public override void Write(string value) => Console.Out.Write(value);
+
+        public override void WriteLine(string value) => Console.Out.WriteLine(value);
+    }
+}

--- a/Microsoft.Dynamics365.UIAutomation.Sample/Microsoft.Dynamics365.UIAutomation.Sample.csproj
+++ b/Microsoft.Dynamics365.UIAutomation.Sample/Microsoft.Dynamics365.UIAutomation.Sample.csproj
@@ -96,6 +96,7 @@
     <Compile Include="UCI\CommandBar\CloseOpportunity.cs" />
     <Compile Include="UCI\CommandBar\DuplicateDetection.cs" />
     <Compile Include="UCI\CommandBar\SelectDashboard.cs" />
+    <Compile Include="ConsoleTraceListener.cs" />
     <Compile Include="UCI\Controls\Grid.cs" />
     <Compile Include="UCI\Create\CreateAccount.cs" />
     <Compile Include="UCI\Create\CreateCase.cs" />

--- a/Microsoft.Dynamics365.UIAutomation.Sample/UCI/ApiTests/TestsBase_Tests.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Sample/UCI/ApiTests/TestsBase_Tests.cs
@@ -1,7 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
-
-using System;
+﻿using System;
+using System.Diagnostics;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.Dynamics365.UIAutomation.Sample.UCI.ApiTests
@@ -46,6 +44,26 @@ namespace Microsoft.Dynamics365.UIAutomation.Sample.UCI.ApiTests
                 Assert.IsNull(_xrmApp, "Browser still open");
                 Assert.IsNull(_client, "Browser still open");
             }
+        }
+
+        [TestMethod]
+        public void WriteTraces_in_AzurePipeline()
+        {
+            trace.Log("Start");
+            Console.WriteLine("Console.WriteLine");
+            Trace.WriteLine("Trace.WriteLine");
+            trace.Log("End");
+            Assert.Inconclusive("Check that this test is printing the traces properly");
+        }
+        
+        [TestMethod]
+        public void WriteTraces_SecoundTest_DontWrite_ToTraceSource()
+        {
+            trace.Log("Start");
+            Console.WriteLine("Console.WriteLine");
+            Trace.WriteLine("Trace.WriteLine");
+            trace.Log("End");
+            Assert.Inconclusive("Check that this test is printing the traces properly");
         }
     }
 }

--- a/Microsoft.Dynamics365.UIAutomation.Sample/UCI/Controls/Grid.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Sample/UCI/Controls/Grid.cs
@@ -3,20 +3,12 @@
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.Dynamics365.UIAutomation.Api.UCI;
-using Microsoft.Dynamics365.UIAutomation.Browser;
-using System;
-using System.Security;
 
 namespace Microsoft.Dynamics365.UIAutomation.Sample.UCI
 {
     [TestClass]
     public class Grid : TestsBase
     {
-
-        private readonly SecureString _username = System.Configuration.ConfigurationManager.AppSettings["OnlineUsername"].ToSecureString();
-        private readonly SecureString _password = System.Configuration.ConfigurationManager.AppSettings["OnlinePassword"].ToSecureString();
-        private readonly Uri _xrmUri = new Uri(System.Configuration.ConfigurationManager.AppSettings["OnlineCrmUrl"].ToString());
-
         [TestMethod]
         public void UCIGridSort()
         {

--- a/Microsoft.Dynamics365.UIAutomation.Sample/UCI/TestsBase.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Sample/UCI/TestsBase.cs
@@ -22,15 +22,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Sample.UCI
         protected WebClient _client;
       
         public TestContext TestContext { get; set; }
-
-        private static TestContext _testContext;
-
-        [ClassInitialize]
-        public static void SetupTests(TestContext testContext)
-        {
-            _testContext = testContext;
-        }
-
+        
         public virtual void InitTest()
         {
             try

--- a/Microsoft.Dynamics365.UIAutomation.Sample/UCI/TestsBase.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Sample/UCI/TestsBase.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Enable System.Diagnostics Trace/Debug
+#define DEBUG 
+#define TRACE
+
+using System;
 using System.Configuration;
 using System.Security;
 using Microsoft.Dynamics365.UIAutomation.Api.UCI;
@@ -14,20 +18,25 @@ namespace Microsoft.Dynamics365.UIAutomation.Sample.UCI
         protected readonly SecureString _username = ConfigurationManager.AppSettings["OnlineUsername"]?.ToSecureString();
         protected readonly SecureString _password = ConfigurationManager.AppSettings["OnlinePassword"]?.ToSecureString();
         protected readonly SecureString _mfaSecrectKey = ConfigurationManager.AppSettings["MfaSecrectKey"]?.ToSecureString();
-  
-        private TracingService _trace;
-        protected TracingService trace => _trace ?? (_trace = new TracingService(GetType(), "BrowserAutomation"));
+        protected readonly TracingService trace;
 
         protected XrmApp _xrmApp;
         protected WebClient _client;
       
-        public TestContext TestContext { get; set; }
+        public TestContext TestContext { get; set; } // VSTest fulfill this property before run each test, remove for NUnit
+        public  virtual string CurrentTestName => TestContext.TestName; // NUnit => replace or override this method with: TestContext.CurrentContext.Test.Name
+
+        protected TestsBase()
+        {
+            trace = new TracingService(GetType(), Constants.DefaultTraceSource);
+            trace.Log("Init Tracing Service - Success");
+        }
         
         public virtual void InitTest()
         {
             try
             {  
-                trace.Log(TestContext.TestName);
+                trace.Log(CurrentTestName);
                 CreateApp();
                 NavigateToHomePage();
             }
@@ -37,11 +46,11 @@ namespace Microsoft.Dynamics365.UIAutomation.Sample.UCI
                 throw;
             }
         }
-
+        
         public virtual void FinishTest()
         {
             CloseApp();
-            trace.Log(TestContext.TestName);
+            trace.Log(CurrentTestName);
         }
 
         public XrmApp CreateApp(BrowserOptions options = null)

--- a/Microsoft.Dynamics365.UIAutomation.Sample/app.config
+++ b/Microsoft.Dynamics365.UIAutomation.Sample/app.config
@@ -58,7 +58,12 @@
       </listeners>
     </trace>
     <sharedListeners>
-      <add name="console" type="System.Diagnostics.ConsoleTraceListener"/> 
+      <!-- 
+      Do not work for more than one test in VS Test Fremework, but work fine for NUnit:
+      <add name="console" type="System.Diagnostics.ConsoleTraceListener"/>  
+      see more: https://stackoverflow.com/questions/36327531/why-are-messages-sent-to-trace-source-missing-from-all-but-the-first-unit-test, 
+      A Custom TraceListener solve this problem: --> 
+      <add name="console" type="Microsoft.Dynamics365.UIAutomation.Sample.ConsoleTraceListener, Microsoft.Dynamics365.UIAutomation.Sample"/> 
       <!--<add name="uiTestTraces" type="System.Diagnostics.TextWriterTraceListener" initializeData="ui-tests-traces.log" />-->  
     </sharedListeners> 
   </system.diagnostics>  

--- a/Microsoft.Dynamics365.UIAutomation.Sample/app.config
+++ b/Microsoft.Dynamics365.UIAutomation.Sample/app.config
@@ -36,4 +36,30 @@
       </providers>
     </roleManager>
   </system.web>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" /></startup></configuration>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" />
+  </startup>
+  <system.diagnostics>
+    <sources>  
+      <source name="BrowserAutomation" switchName="sourceSwitch" >  
+        <listeners>  
+          <add name="console" />
+          <!--<add name="uiTestTraces" />-->
+        </listeners>  
+      </source>  
+    </sources>  
+    <switches>  
+      <add name="sourceSwitch" value="Verbose" />  
+    </switches>  
+    <trace autoflush="true" indentsize="4">
+      <listeners>
+        <add name="console" />
+        <!--<add name="uiTestTraces" />-->
+      </listeners>
+    </trace>
+    <sharedListeners>
+      <add name="console" type="System.Diagnostics.ConsoleTraceListener"/> 
+      <!--<add name="uiTestTraces" type="System.Diagnostics.TextWriterTraceListener" initializeData="ui-tests-traces.log" />-->  
+    </sharedListeners> 
+  </system.diagnostics>  
+</configuration>


### PR DESCRIPTION
### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (updates to documentation, formatting, etc.)

### Description
- Add traces configuration in sample project.
- Add helper classes related to traces.
- Add Trace basic infos about the related test in the UCI TestsBase class.
TODO: The configuration is simple. I add some comments, but create proper Documentation is highly recommended to show the different scenarios; for example: Send Traces to a Text File, use with NUnit, configure in DevOps, etc.

### Issues addressed
See #775 [FEATURE] Enable Traces by default in Samples Project

### All submissions:
- [x] My code follows the code style of this project.
- [x] Do existing samples that are effected by this change still run?
- [x] I have added samples for new functionality. 
- [x] I raise detailed error messages when possible.
- [x] My code does not rely on labels that have the option to be hidden.

### Which browsers was this tested on?
<!--- Should be tested on Chrome, Firefox, and IE. -->
- [x] Chrome
- [ ] Firefox
- [ ] IE
- [ ] Edge

Tests Results on Build Pipeline:
![image](https://user-images.githubusercontent.com/27274469/75101230-722c6e00-55d9-11ea-93f5-80586310bab9.png)

Attached Traces (download is allowed):
![image](https://user-images.githubusercontent.com/27274469/75101350-9ee18500-55db-11ea-8e17-4ab891141a43.png)

[Standard_Console_Output (example Lookup not found).log](https://github.com/microsoft/EasyRepro/files/4240438/Standard_Console_Output.example.Lookup.not.found.log)

[Standard_Console_Output (example Login Fail).log](https://github.com/microsoft/EasyRepro/files/4240436/Standard_Console_Output.example.Login.Fail.log)

**NOTE**: I found a problem with the standard "System.Diagnostics.ConsoleTraceListener". Using the MSTest just the first test print the traces to the Standard Output, to fix this a custom TraceListener 
 implementation is required. 
See more information about the error & the workaround [here](https://stackoverflow.com/questions/36327531/why-are-messages-sent-to-trace-source-missing-from-all-but-the-first-unit-test).
For NUnit is the custom TraceListener not required, a respective explanatory comment is added in app.config.
