### PR TITLE
Get form notifications on a form

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/AppElementReference.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/AppElementReference.cs
@@ -131,7 +131,13 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             public static string EntityOptionsetStatusComboButton = "Entity_OptionsetStatusComboButton";
             public static string EntityOptionsetStatusComboList = "Entity_OptionsetStatusComboList";
             public static string EntityOptionsetStatusTextValue = "Entity_OptionsetStatusTextValue";
-            
+            public static string FormNotifcationBar = "Entity_FormNotifcationBar";
+            public static string FormNotifcationExpandButton = "Entity_FormNotifcationExpandButton"; 
+            public static string FormNotifcationFlyoutRoot = "Entity_FormNotifcationFlyoutRoot";
+            public static string FormNotifcationList = "Entity_FormNotifcationList";
+            public static string FormNotifcationTypeIcon = "Entity_FormNotifcationTypeIcon";
+
+
             public static class Header
             {
                 public static string Container = "Entity_Header";
@@ -385,6 +391,11 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             { "Entity_OptionsetStatusComboButton", "//div[contains(@id, '[NAME].fieldControl-pickliststatus-comboBox_button')]"},
             { "Entity_OptionsetStatusComboList", "//ul[contains(@id, '[NAME].fieldControl-pickliststatus-comboBox_list')]"},
             { "Entity_OptionsetStatusTextValue", "//span[contains(@id, '[NAME].fieldControl-pickliststatus-comboBox_text-value')]"},
+            { "Entity_FormNotifcationBar", "//div[@data-id='notificationWrapper']" },
+            { "Entity_FormNotifcationExpandButton", ".//span[@id='notificationExpandIcon']" },
+            { "Entity_FormNotifcationFlyoutRoot", "//div[@id='__flyoutRootNode']" },
+            { "Entity_FormNotifcationList", ".//ul[@data-id='notificationList']" },
+            { "Entity_FormNotifcationTypeIcon", ".//span[contains(@id,'notification_icon_')]" },
 
             //Entity Header
             { "Entity_Header", "//div[contains(@data-id,'form-header')]"},

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/FormNotification.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/FormNotification.cs
@@ -1,7 +1,18 @@
-﻿namespace Microsoft.Dynamics365.UIAutomation.Api.UCI.DTO
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.Dynamics365.UIAutomation.Api.UCI.DTO
 {
     public class FormNotification
     {
+        private static readonly Dictionary<string, FormNotificationType> _classToTypeMap = new Dictionary<string, FormNotificationType>{
+            {"markaslost-symbol", FormNotificationType.Error},
+            {"warning-symbol", FormNotificationType.Warning},
+            {"informationicon-symbol", FormNotificationType.Information}
+        };
+
+
         public FormNotificationType Type { get; set; }
         public string Message { get; set; }
 
@@ -9,5 +20,17 @@
         {
             return $"{Type}: {Message}";
         }
+
+        public void SetTypeFromClass(string classes)
+        {
+            string[] classesArr = classes.ToLower().Split(' ');
+            string classFound = classesArr.FirstOrDefault(c => _classToTypeMap.ContainsKey(c));
+
+            if (classFound == null)
+                throw new InvalidOperationException($"Unknown notification type. Current class: {classes}");
+
+            Type = _classToTypeMap[classFound];
+        }
+        
     }
 }

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/FormNotification.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/FormNotification.cs
@@ -1,0 +1,13 @@
+﻿namespace Microsoft.Dynamics365.UIAutomation.Api.UCI.DTO
+{
+    public class FormNotification
+    {
+        public FormNotificationType Type { get; set; }
+        public string Message { get; set; }
+
+        public override string ToString()
+        {
+            return $"{Type}: {Message}";
+        }
+    }
+}

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/FormNotificationType.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/FormNotificationType.cs
@@ -1,0 +1,9 @@
+﻿namespace Microsoft.Dynamics365.UIAutomation.Api.UCI.DTO
+{
+    public enum FormNotificationType
+    {
+        Information,
+        Warning,
+        Error
+    }
+}

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/Elements/Entity.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/Elements/Entity.cs
@@ -117,7 +117,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 
         public IReadOnlyCollection<FormNotification> GetFormNotifications()
         {
-            return _client.GetFormNotifications();
+            return _client.GetFormNotifications().Value;
         }
 
         /// <summary>

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/Elements/Entity.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/Elements/Entity.cs
@@ -115,7 +115,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             return _client.GetStatusFromFooter();
         }
 
-        public IReadOnlyCollection<FormNotification> GetFormNotifications()
+        public IReadOnlyList<FormNotification> GetFormNotifications()
         {
             return _client.GetFormNotifications().Value;
         }

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/Elements/Entity.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/Elements/Entity.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
+using Microsoft.Dynamics365.UIAutomation.Api.UCI.DTO;
 using Microsoft.Dynamics365.UIAutomation.Browser;
 using System;
 using System.Collections.Generic;
@@ -112,6 +113,11 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         public string GetFooterStatusValue()
         {
             return _client.GetStatusFromFooter();
+        }
+
+        public IReadOnlyCollection<FormNotification> GetFormNotifications()
+        {
+            return _client.GetFormNotifications();
         }
 
         /// <summary>

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/Microsoft.Dynamics365.UIAutomation.Api.UCI.csproj
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/Microsoft.Dynamics365.UIAutomation.Api.UCI.csproj
@@ -81,6 +81,8 @@
     <Compile Include="Controls\MultiValueOptionSet.cs" />
     <Compile Include="Controls\BooleanItem.cs" />
     <Compile Include="Controls\OptionSet.cs" />
+    <Compile Include="DTO\FormNotification.cs" />
+    <Compile Include="DTO\FormNotificationType.cs" />
     <Compile Include="DTO\KeyPerformanceIndicator.cs" />
     <Compile Include="Elements\BusinessProcessFlow.cs" />
     <Compile Include="Elements\CommandBar.cs" />

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -3351,11 +3351,9 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             {
                 List<FormNotification> notifications = new List<FormNotification>();
 
-                if (!driver.TryFindElement(By.XPath(AppElements.Xpath[AppReference.Entity.FormNotifcationBar]),
-                    out var notificationBar))
-                {
+                var notificationBar = driver.WaitUntilVisible(By.XPath(AppElements.Xpath[AppReference.Entity.FormNotifcationBar]), TimeSpan.FromSeconds(2));
+                if (notificationBar == null)
                     return notifications;
-                }
 
                 if (notificationBar.TryFindElement(By.XPath(AppElements.Xpath[AppReference.Entity.FormNotifcationExpandButton]), out var expandButton))
                 {
@@ -3376,16 +3374,8 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                     {
                         Message = item.GetAttribute("aria-label")
                     };
-
-                    if (icon.HasClass("MarkAsLost-symbol"))
-                        notification.Type = FormNotificationType.Error;
-                    else if (icon.HasClass("Warning-symbol"))
-                        notification.Type = FormNotificationType.Warning;
-                    else if (icon.HasClass("InformationIcon-symbol"))
-                        notification.Type = FormNotificationType.Information;
-                    else
-                        throw new InvalidOperationException($"Unknown notification type. Current class: {icon.GetAttribute("class")}");
-
+                    string classes = icon.GetAttribute("class");
+                    notification.SetTypeFromClass(classes);
                     notifications.Add(notification);
                 }
                 return notifications;

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -3351,15 +3351,19 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             {
                 List<FormNotification> notifications = new List<FormNotification>();
 
+                // Look for the notification bar, if it doesn't exist there are no notificatios
                 var notificationBar = driver.WaitUntilVisible(By.XPath(AppElements.Xpath[AppReference.Entity.FormNotifcationBar]), TimeSpan.FromSeconds(2));
                 if (notificationBar == null)
                     return notifications;
 
-                if (notificationBar.TryFindElement(By.XPath(AppElements.Xpath[AppReference.Entity.FormNotifcationExpandButton]), out var expandButton))
+                // If there are multiple notifications, the notifications must be expanded first.
+                var expandButton = notificationBar.FindElement(By.XPath(AppElements.Xpath[AppReference.Entity.FormNotifcationExpandButton]));
+                if(expandButton != null)
                 {
                     if (!Convert.ToBoolean(notificationBar.GetAttribute("aria-expanded")))
                         expandButton.Click();
 
+                    // After expansion the list of notifications are now in a different element
                     notificationBar = driver.WaitUntilAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.FormNotifcationFlyoutRoot]), TimeSpan.FromSeconds(2), "Failed to open the form notifications");
                 }
 

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -3345,7 +3345,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             });
         }
 
-        internal BrowserCommandResult<IReadOnlyCollection<FormNotification>> GetFormNotifications()
+        internal BrowserCommandResult<IReadOnlyList<FormNotification>> GetFormNotifications()
         {
             return Execute(GetOptions($"Get all form notifications"), driver =>
             {
@@ -3357,8 +3357,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                     return notifications;
 
                 // If there are multiple notifications, the notifications must be expanded first.
-                var expandButton = notificationBar.FindElement(By.XPath(AppElements.Xpath[AppReference.Entity.FormNotifcationExpandButton]));
-                if(expandButton != null)
+                if(notificationBar.TryFindElement(By.XPath(AppElements.Xpath[AppReference.Entity.FormNotifcationExpandButton]), out var expandButton))
                 {
                     if (!Convert.ToBoolean(notificationBar.GetAttribute("aria-expanded")))
                         expandButton.Click();

--- a/Microsoft.Dynamics365.UIAutomation.Browser/Extensions/SeleniumExtensions.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Browser/Extensions/SeleniumExtensions.cs
@@ -205,6 +205,9 @@ namespace Microsoft.Dynamics365.UIAutomation.Browser
         public static bool HasAttribute(this IWebElement element, string attributeName)
             => element.GetAttribute(attributeName) != null;
 
+        public static bool HasClass(this IWebElement element, string className)
+            => element.GetAttribute("class").Split(' ').Any(c => string.Equals(className, c, StringComparison.CurrentCultureIgnoreCase));
+        
         public static T GetAttribute<T>(this IWebElement element, string attributeName)
         {
             string value = element.GetAttribute(attributeName) ?? string.Empty;

--- a/Microsoft.Dynamics365.UIAutomation.Browser/Extensions/SeleniumExtensions.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Browser/Extensions/SeleniumExtensions.cs
@@ -205,9 +205,6 @@ namespace Microsoft.Dynamics365.UIAutomation.Browser
         public static bool HasAttribute(this IWebElement element, string attributeName)
             => element.GetAttribute(attributeName) != null;
 
-        public static bool HasClass(this IWebElement element, string className)
-            => element.GetAttribute("class").Split(' ').Any(c => string.Equals(className, c, StringComparison.CurrentCultureIgnoreCase));
-        
         public static T GetAttribute<T>(this IWebElement element, string attributeName)
         {
             string value = element.GetAttribute(attributeName) ?? string.Empty;

--- a/Microsoft.Dynamics365.UIAutomation.Sample/Microsoft.Dynamics365.UIAutomation.Sample.csproj
+++ b/Microsoft.Dynamics365.UIAutomation.Sample/Microsoft.Dynamics365.UIAutomation.Sample.csproj
@@ -102,6 +102,7 @@
     <Compile Include="UCI\Create\CreateLead.cs" />
     <Compile Include="UCI\Create\CreateActivity.cs" />
     <Compile Include="UCI\Create\CreateOpportunity.cs" />
+    <Compile Include="UCI\FormNotifications\ReadFormNotifications.cs" />
     <Compile Include="UCI\TestsBase.cs" />
     <Compile Include="UCI\Delete\DeleteAccount.cs" />
     <Compile Include="UCI\Delete\DeleteCase.cs" />

--- a/Microsoft.Dynamics365.UIAutomation.Sample/UCI/FormNotifications/ReadFormNotifications.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Sample/UCI/FormNotifications/ReadFormNotifications.cs
@@ -1,0 +1,42 @@
+﻿using Microsoft.Dynamics365.UIAutomation.Api.UCI;
+using Microsoft.Dynamics365.UIAutomation.Api.UCI.DTO;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Dynamics365.UIAutomation.Sample.UCI
+{
+    [TestClass] 
+    public class ReadFormNotifications : TestsBase
+    {
+        [TestInitialize]
+        public override void InitTest() => base.InitTest();
+
+        [TestCleanup]
+        public override void FinishTest() => base.FinishTest();
+
+        public override void NavigateToHomePage() => _xrmApp.Navigation.OpenSubArea("Sales", "Leads");
+
+
+        [TestMethod]
+        public void UCITestReadFormNotifications()
+        {
+            _xrmApp.CommandBar.ClickCommand("New");
+            
+            _xrmApp.Entity.SetValue("lastname", "Test");
+            
+            _xrmApp.ThinkTime(5000);
+            _xrmApp.Entity.Save();
+
+            var notifications = _xrmApp.Entity.GetFormNotifications();
+
+            Assert.AreEqual(1, notifications.Count);
+            Assert.AreEqual(FormNotificationType.Error, notifications[0].Type);
+            Assert.AreEqual("Topic : Required fields must be filled in.", notifications[0].Message);
+            
+        }
+    }
+}


### PR DESCRIPTION
### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Other (updates to documentation, formatting, etc.)

### Description
I'm my SpecFlow based test framework I got a functionality that retrieves form notifications. I think it could be a great addition to EasyRepro.

### Issues addressed
Some requirements add form notifications, you can automatically verify that they appear at the expected times. 

Secondary I also use it for logging when an error appears somewhere. Sometimes these notifications offer a good explaination what is going on. In example when your save fails due to a required field not being filled in. You will see that in the form notifications. Also some ribbon commands present a form notification instead of a dialog.

### All submissions:

- [X] My code follows the code style of this project.
- [X] Do existing samples that are effected by this change still run?
- [ ] I have added samples for new functionality. 
- [X] I raise detailed error messages when possible.
- [X] My code does not rely on labels that have the option to be hidden.

I didn't include any samples that I have to test this in my own framework, because they rely on customizations done on the environment that triggers these notifications. If you have some good ideas for a sample, I'm happy to add them to this pull request.

### Which browsers was this tested on?
<!--- Should be tested on Chrome, Firefox, and IE. -->
- [X] Chrome
- [ ] Firefox
- [ ] IE
- [ ] Edge
