### PR TITLE
Removed failure callback from TryToClickInAppTile()

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -406,8 +406,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                     }
                     return true;
                 },
-                TimeSpan.FromSeconds(30),
-                failureCallback: () => throw new InvalidOperationException(message)
+                TimeSpan.FromSeconds(30) // Removed failure callback. A thrown exception here will cause a browser failure which is not desired.
                 );
 
             var xpathToAppContainer = By.XPath(AppElements.Xpath[AppReference.Navigation.UCIAppContainer]);

--- a/Microsoft.Dynamics365.UIAutomation.Sample/UCI/TestsBase.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Sample/UCI/TestsBase.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Sample.UCI
             _client = new WebClient(options);
             _xrmApp = new XrmApp(_client);
 
-            _xrmApp.OnlineLogin.Login(_xrmUri, _username, _password, _mfaSecrectKey);
+            _xrmApp.OnlineLogin.Login(_xrmUri, _username, _password, _mfaSecretKey);
             
             trace.Log("Success");
 


### PR DESCRIPTION
### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (updates to documentation, formatting, etc.)

### Description
Removing failure callback from TryToClickInAppTile() as this causes an exception and critical failure if you land on the legacy web client page.

### Issues addressed
Critical exception occurs if you land on the wrong page after login.

### All submissions:

- [X] My code follows the code style of this project.
- [X] Do existing samples that are effected by this change still run?
- [ ] I have added samples for new functionality. 
- [ ] I raise detailed error messages when possible.
- [X] My code does not rely on labels that have the option to be hidden.

### Which browsers was this tested on?
<!--- Should be tested on Chrome, Firefox, and IE. -->
- [X] Chrome
- [X] Firefox
- [ ] IE
- [ ] Edge
