### PR TITLE
Add support for Boolean OptionSet button type

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/AppElementReference.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/AppElementReference.cs
@@ -124,6 +124,9 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             public static string EntityBooleanFieldRadioContainer = "Entity_BooleanFieldRadioContainer";
             public static string EntityBooleanFieldRadioTrue = "Entity_BooleanFieldRadioTrue";
             public static string EntityBooleanFieldRadioFalse = "Entity_BooleanFieldRadioFalse";
+            public static string EntityBooleanFieldButtonContainer = "Entity_BooleanFieldButton";
+            public static string EntityBooleanFieldButtonTrue = "Entity_BooleanFieldButtonTrue";
+            public static string EntityBooleanFieldButtonFalse = "Entity_BooleanFieldButtonFalse";
             public static string EntityBooleanFieldCheckboxContainer = "Entity_BooleanFieldCheckboxContainer";
             public static string EntityBooleanFieldCheckbox = "Entity_BooleanFieldCheckbox";
             public static string EntityBooleanFieldList = "Entity_BooleanFieldList";
@@ -134,7 +137,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             public static string EntityOptionsetStatusComboList = "Entity_OptionsetStatusComboList";
             public static string EntityOptionsetStatusTextValue = "Entity_OptionsetStatusTextValue";
             public static string FormNotifcationBar = "Entity_FormNotifcationBar";
-            public static string FormNotifcationExpandButton = "Entity_FormNotifcationExpandButton"; 
+            public static string FormNotifcationExpandButton = "Entity_FormNotifcationExpandButton";
             public static string FormNotifcationFlyoutRoot = "Entity_FormNotifcationFlyoutRoot";
             public static string FormNotifcationList = "Entity_FormNotifcationList";
             public static string FormNotifcationTypeIcon = "Entity_FormNotifcationTypeIcon";
@@ -389,6 +392,9 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             { "Entity_BooleanFieldList", "//select[contains(@data-id, '[NAME].fieldControl-checkbox-select')]"},
             { "Entity_BooleanFieldFlipSwitchLink", "//div[contains(@data-id, '[NAME]-FieldSectionItemContainer')]"},
             { "Entity_BooleanFieldFlipSwitchContainer", "//div[@data-id= '[NAME].fieldControl_container']"},
+            { "Entity_BooleanFieldButton", "//div[contains(@data-id, '[NAME].fieldControl_container')]"},
+            { "Entity_BooleanFieldButtonTrue", ".//label[contains(@class, 'first-child')]"},
+            { "Entity_BooleanFieldButtonFalse", ".//label[contains(@class, 'last-child')]"},
             { "Entity_OptionSetFieldContainer", "//div[@data-id='[NAME].fieldControl-option-set-container']" },
             { "Entity_OptionsetStatusCombo", "//div[contains(@data-id, '[NAME].fieldControl-pickliststatus-comboBox')]"},
             { "Entity_OptionsetStatusComboButton", "//div[contains(@id, '[NAME].fieldControl-pickliststatus-comboBox_button')]"},

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -565,7 +565,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 return areas;
             });
         }
-        
+
         public Dictionary<string, IWebElement> OpenMenu(int thinkTime = Constants.DefaultThinkTime)
         {
             return Execute(GetOptions("Open Menu"), driver =>
@@ -2073,6 +2073,9 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 var hasCheckbox = fieldContainer.HasElement(By.XPath(AppElements.Xpath[AppReference.Entity.EntityBooleanFieldCheckbox].Replace("[NAME]", option.Name)));
                 var hasList = fieldContainer.HasElement(By.XPath(AppElements.Xpath[AppReference.Entity.EntityBooleanFieldList].Replace("[NAME]", option.Name)));
                 var hasFlipSwitch = fieldContainer.HasElement(By.XPath(AppElements.Xpath[AppReference.Entity.EntityBooleanFieldFlipSwitchLink].Replace("[NAME]", option.Name)));
+                var flipSwitch = hasFlipSwitch ? fieldContainer.FindElement(By.XPath(AppElements.Xpath[AppReference.Entity.EntityBooleanFieldFlipSwitchContainer].Replace("[NAME]", option.Name))) : null;
+                var hasButton = flipSwitch != null ? flipSwitch.HasElement(By.XPath(AppElements.Xpath[AppReference.Entity.EntityBooleanFieldButtonTrue])) : false; 
+                hasFlipSwitch = hasButton ? false : hasFlipSwitch; //flipeSwitch and button have the same container reference, so if it has a button it is not a flipSwitch
 
                 if (hasRadio)
                 {
@@ -2123,6 +2126,21 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                     if (value != option.Value)
                     {
                         link.Click();
+                    }
+                }
+                else if (hasButton)
+                {
+                    var container = fieldContainer.FindElement(By.XPath(AppElements.Xpath[AppReference.Entity.EntityBooleanFieldButtonContainer].Replace("[NAME]", option.Name)));
+                    var trueButton = container.FindElement(By.XPath(AppElements.Xpath[AppReference.Entity.EntityBooleanFieldButtonTrue]));
+                    var falseButton = container.FindElement(By.XPath(AppElements.Xpath[AppReference.Entity.EntityBooleanFieldButtonFalse]));
+
+                    if (option.Value)
+                    {
+                        trueButton.Click();
+                    }
+                    else
+                    {
+                        falseButton.Click();
                     }
                 }
                 else
@@ -2185,11 +2203,11 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 dateField.Click(); // close calendar
 
             driver.RepeatUntil(() =>
-                {
-                    ClearFieldValue(dateField);
-                    if (date != null)
-                        dateField.SendKeys(date);
-                },
+            {
+                ClearFieldValue(dateField);
+                if (date != null)
+                    dateField.SendKeys(date);
+            },
                 d => dateField.GetAttribute("value").IsValueEqualsTo(date),
                 TimeSpan.FromSeconds(9), 3,
                 failureCallback: () => throw new InvalidOperationException($"Timeout after 10 seconds. Expected: {date}. Actual: {dateField.GetAttribute("value")}")
@@ -2222,11 +2240,11 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             driver.WaitForTransaction();
 
             driver.RepeatUntil(() =>
-                {
-                    timeField.Clear();
-                    timeField.Click();
-                    timeField.SendKeys(time);
-                },
+            {
+                timeField.Clear();
+                timeField.Click();
+                timeField.SendKeys(time);
+            },
                 d => timeField.GetAttribute("value").IsValueEqualsTo(time),
                 TimeSpan.FromSeconds(9), 3,
                 failureCallback: () => throw new InvalidOperationException($"Timeout after 10 seconds. Expected: {time}. Actual: {timeField.GetAttribute("value")}")


### PR DESCRIPTION
### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (updates to documentation, formatting, etc.)

### Description
Added AppElement Reference to UCI for BooleanFieldContainer and True / False buttons.
Added check for button control to WebClient.cs

### Issues addressed
If you have a Boolean field displaying as Buttons, EasyRepro fails to set the value

### All submissions:

- [x] My code follows the code style of this project.
- [ ] Do existing samples that are effected by this change still run?
- [ ] I have added samples for new functionality. 
- [ ] I raise detailed error messages when possible.
- [x] My code does not rely on labels that have the option to be hidden.

### Which browsers was this tested on?
<!--- Should be tested on Chrome, Firefox, and IE. -->
- [x] Chrome
- [ ] Firefox
- [ ] IE
- [ ] Edge
