### PR TITLE
Address issue with LookupItem ClearValue/SetValue

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -3034,7 +3034,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 var xpathToHoveExistingValue = By.XPath(AppElements.Xpath[AppReference.Entity.LookupFieldHoverExistingValue].Replace("[NAME]", controlName));
                 var found = fieldContainer.TryFindElement(xpathToHoveExistingValue, out var existingList);
                 if (found)
-                    existingList.SendKeys(Keys.Clear);
+                    existingList.Click(true);
             }
 
             fieldContainer.WaitUntilAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.TextFieldLookupSearchButton].Replace("[NAME]", controlName)));


### PR DESCRIPTION
### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (updates to documentation, formatting, etc.)

### Description
In order for the lookupitem control to be usable, you must first click into the field. 

### Issues addressed
This addresses the issues related to SetValue and ClearValue for a LookupItem
https://github.com/microsoft/EasyRepro/issues/804
https://github.com/microsoft/EasyRepro/issues/791

### All submissions:

- [X] My code follows the code style of this project.
- [X] Do existing samples that are effected by this change still run?
- [ ] I have added samples for new functionality. 
- [X] I raise detailed error messages when possible.
- [X] My code does not rely on labels that have the option to be hidden.

### Which browsers was this tested on?
<!--- Should be tested on Chrome, Firefox, and IE. -->
- [X] Chrome
- [ ] Firefox
- [ ] IE
- [ ] Edge
