### PR TITLE
Keys already present in the dictionary with custom props/metrics

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/Elements/Telemetry.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/Elements/Telemetry.cs
@@ -52,8 +52,11 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 var properties = new Dictionary<string, string>();
                 var metrics = new Dictionary<string, double>();
 
-                if (additionalProperties != null) properties = additionalProperties;
-                if (additionalMetrics != null) metrics = additionalMetrics;
+                if (additionalMetrics != null && additionalMetrics.Count > 0)
+                    metrics = metrics.Merge(additionalMetrics);
+
+                if (additionalProperties != null && additionalProperties.Count > 0)
+                    properties = properties.Merge(additionalProperties);
 
                 properties.Add("StartTime", x.StartTime.Value.ToLongDateString());
                 properties.Add("EndTime", x.StopTime.Value.ToLongDateString());


### PR DESCRIPTION
Observed that when using the TrackCommandEvents, when adding custom props and metrics to it, it was having issues with keys already being present in the dictionaries, by merging them rather than assigning it, we prevent this issue from happening. Same what its being done in the TrackPerformanceEvents.

![image](https://user-images.githubusercontent.com/2614497/79997427-7da0f600-84b1-11ea-8a1a-2b754a151dce.png)


### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (updates to documentation, formatting, etc.)

### Description
Instead of reassigning the props and metrics dictionaries all the time, we are merging them to prevent errors around given keys already present in the dictionary.

### Issues addressed
Basically using the same approach as in TrackPerformanceEvents we are merging the dictionaries instead.

### All submissions:

- [x] My code follows the code style of this project.
- [x] Do existing samples that are effected by this change still run?
- [ ] I have added samples for new functionality. 
- [x] I raise detailed error messages when possible.
- [x] My code does not rely on labels that have the option to be hidden.

### Which browsers was this tested on?
<!--- Should be tested on Chrome, Firefox, and IE. -->
- [x] Chrome
- [x] Firefox
- [ ] IE
- [ ] Edge
