### PR TITLE
Fixes for Set/Get Header Values

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/Elements/Entity.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/Elements/Entity.cs
@@ -380,7 +380,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         /// <param name="control">The lookup field name, value or index of the lookup.</param>
         public void SetHeaderValue(LookupItem control)
         {
-            _client.SetHeaderValue(control);            
+            _client.SetHeaderValue(control);
         }
 
         /// <summary>

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/Elements/Entity.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/Elements/Entity.cs
@@ -380,7 +380,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         /// <param name="control">The lookup field name, value or index of the lookup.</param>
         public void SetHeaderValue(LookupItem control)
         {
-            _client.SetHeaderValue(control);
+            _client.SetHeaderValue(control);            
         }
 
         /// <summary>

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/Microsoft.Dynamics365.UIAutomation.Api.UCI.csproj
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/Microsoft.Dynamics365.UIAutomation.Api.UCI.csproj
@@ -108,6 +108,7 @@
     <Compile Include="DTO\ListItem.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
@@ -117,15 +118,6 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Selenium.Firefox.WebDriver.0.24.0\build\Selenium.Firefox.WebDriver.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Selenium.Firefox.WebDriver.0.24.0\build\Selenium.Firefox.WebDriver.targets'))" />
-    <Error Condition="!Exists('..\packages\Selenium.Chrome.WebDriver.76.0.0\build\Selenium.Chrome.WebDriver.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Selenium.Chrome.WebDriver.76.0.0\build\Selenium.Chrome.WebDriver.targets'))" />
-  </Target>
-  <Import Project="..\packages\Selenium.Firefox.WebDriver.0.24.0\build\Selenium.Firefox.WebDriver.targets" Condition="Exists('..\packages\Selenium.Firefox.WebDriver.0.24.0\build\Selenium.Firefox.WebDriver.targets')" />
-  <Import Project="..\packages\Selenium.Chrome.WebDriver.76.0.0\build\Selenium.Chrome.WebDriver.targets" Condition="Exists('..\packages\Selenium.Chrome.WebDriver.76.0.0\build\Selenium.Chrome.WebDriver.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/Microsoft.Dynamics365.UIAutomation.Api.UCI.csproj
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/Microsoft.Dynamics365.UIAutomation.Api.UCI.csproj
@@ -108,7 +108,6 @@
     <Compile Include="DTO\ListItem.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -2256,6 +2256,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 timeField.Clear();
                 timeField.Click();
                 timeField.SendKeys(time);
+                timeField.SendKeys(Keys.Tab);
             },
                 d => timeField.GetAttribute("value").IsValueEqualsTo(time),
                 TimeSpan.FromSeconds(9), 3,
@@ -2411,7 +2412,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                         var timefields = driver.FindElements(By.XPath(AppElements.Xpath[AppReference.Entity.FieldControlDateTimeTimeInputUCI].Replace("[FIELD]", field)));
                         if (timefields.Any())
                         {
-                            text = $" {timefields.First().GetAttribute("value")}";
+                            text += $" {timefields.First().GetAttribute("value")}";
                         }
                     }
                 }

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/packages.config
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/packages.config
@@ -3,8 +3,6 @@
   <package id="Microsoft.ApplicationInsights" version="2.11.0" targetFramework="net46" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net46" />
   <package id="Otp.NET" version="1.2.1" targetFramework="net46" />
-  <package id="Selenium.Chrome.WebDriver" version="76.0.0" targetFramework="net46" />
-  <package id="Selenium.Firefox.WebDriver" version="0.24.0" targetFramework="net46" />
   <package id="Selenium.Support" version="3.141.0" targetFramework="net46" />
   <package id="Selenium.WebDriver" version="3.141.0" targetFramework="net46" />
   <package id="System.Buffers" version="4.4.0" targetFramework="net46" />

--- a/Microsoft.Dynamics365.UIAutomation.Api/Microsoft.Dynamics365.UIAutomation.Api.csproj
+++ b/Microsoft.Dynamics365.UIAutomation.Api/Microsoft.Dynamics365.UIAutomation.Api.csproj
@@ -124,15 +124,6 @@
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Selenium.Firefox.WebDriver.0.24.0\build\Selenium.Firefox.WebDriver.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Selenium.Firefox.WebDriver.0.24.0\build\Selenium.Firefox.WebDriver.targets'))" />
-    <Error Condition="!Exists('..\packages\Selenium.Chrome.WebDriver.76.0.0\build\Selenium.Chrome.WebDriver.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Selenium.Chrome.WebDriver.76.0.0\build\Selenium.Chrome.WebDriver.targets'))" />
-  </Target>
-  <Import Project="..\packages\Selenium.Firefox.WebDriver.0.24.0\build\Selenium.Firefox.WebDriver.targets" Condition="Exists('..\packages\Selenium.Firefox.WebDriver.0.24.0\build\Selenium.Firefox.WebDriver.targets')" />
-  <Import Project="..\packages\Selenium.Chrome.WebDriver.76.0.0\build\Selenium.Chrome.WebDriver.targets" Condition="Exists('..\packages\Selenium.Chrome.WebDriver.76.0.0\build\Selenium.Chrome.WebDriver.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Microsoft.Dynamics365.UIAutomation.Api/packages.config
+++ b/Microsoft.Dynamics365.UIAutomation.Api/packages.config
@@ -1,8 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net461" />
-  <package id="Selenium.Chrome.WebDriver" version="76.0.0" targetFramework="net46" />
-  <package id="Selenium.Firefox.WebDriver" version="0.24.0" targetFramework="net46" />
   <package id="Selenium.Support" version="3.141.0" targetFramework="net46" />
   <package id="Selenium.WebDriver" version="3.141.0" targetFramework="net46" />
 </packages>

--- a/Microsoft.Dynamics365.UIAutomation.Browser/Microsoft.Dynamics365.UIAutomation.Browser.csproj
+++ b/Microsoft.Dynamics365.UIAutomation.Browser/Microsoft.Dynamics365.UIAutomation.Browser.csproj
@@ -107,15 +107,6 @@
     </EmbeddedResource>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Selenium.Firefox.WebDriver.0.24.0\build\Selenium.Firefox.WebDriver.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Selenium.Firefox.WebDriver.0.24.0\build\Selenium.Firefox.WebDriver.targets'))" />
-    <Error Condition="!Exists('..\packages\Selenium.Chrome.WebDriver.76.0.0\build\Selenium.Chrome.WebDriver.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Selenium.Chrome.WebDriver.76.0.0\build\Selenium.Chrome.WebDriver.targets'))" />
-  </Target>
-  <Import Project="..\packages\Selenium.Firefox.WebDriver.0.24.0\build\Selenium.Firefox.WebDriver.targets" Condition="Exists('..\packages\Selenium.Firefox.WebDriver.0.24.0\build\Selenium.Firefox.WebDriver.targets')" />
-  <Import Project="..\packages\Selenium.Chrome.WebDriver.76.0.0\build\Selenium.Chrome.WebDriver.targets" Condition="Exists('..\packages\Selenium.Chrome.WebDriver.76.0.0\build\Selenium.Chrome.WebDriver.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Microsoft.Dynamics365.UIAutomation.Browser/packages.config
+++ b/Microsoft.Dynamics365.UIAutomation.Browser/packages.config
@@ -3,8 +3,6 @@
     Licensed under the MIT license.-->
 <packages>
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net46" />
-  <package id="Selenium.Chrome.WebDriver" version="76.0.0" targetFramework="net46" />
-  <package id="Selenium.Firefox.WebDriver" version="0.24.0" targetFramework="net46" />
   <package id="Selenium.Support" version="3.141.0" targetFramework="net46" />
   <package id="Selenium.WebDriver" version="3.141.0" targetFramework="net46" />
 </packages>


### PR DESCRIPTION
### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (updates to documentation, formatting, etc.)

### Description
- Remove browser drivers from Api, Api.UCI, and Browser projects (GeckoWebDriver/ChromeWebDriver)
- SetHeaderValue fix when fields exist in Header and on Form
- GetHeaderValue fix when fields exist in Header and on Form
- GetHeaderValue fix for DateTimeControl if Date & Time are present (prior behavior was only outputting Time value and excluding date)
- SetHeaderValue fix for DateTimeControl if Date & Time input is present (prior behavior would not always set the expected time value)

### Issues addressed
#836 
#837 

### All submissions:

- [x] My code follows the code style of this project.
- [x] Do existing samples that are effected by this change still run?
- [x] My code does not rely on labels that have the option to be hidden.

### Which browsers was this tested on?
<!--- Should be tested on Chrome, Firefox, and IE. -->
- [x] Chrome
- [ ] Firefox
- [ ] IE
- [ ] Edge
