### PR TITLE
Adding new GetFooterMessageValue method

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/AppElementReference.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/AppElementReference.cs
@@ -123,6 +123,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             public static string DuplicateDetectionGridRows = "Entity_DuplicateDetectionGridRows";
             public static string DuplicateDetectionIgnoreAndSaveButton = "Entity_DuplicateDetectionIgnoreAndSaveButton";
             public static string FooterStatusValue = "Entity_FooterStatusField";
+            public static string FooterMessageValue = "Entity_FooterMessage";
             public static string EntityBooleanFieldRadioContainer = "Entity_BooleanFieldRadioContainer";
             public static string EntityBooleanFieldRadioTrue = "Entity_BooleanFieldRadioTrue";
             public static string EntityBooleanFieldRadioFalse = "Entity_BooleanFieldRadioFalse";
@@ -388,6 +389,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             { "Entity_DuplicateDetectionGridRows", "//div[contains(@class,'data-selectable')]" },
             { "Entity_DuplicateDetectionIgnoreAndSaveButton", "//button[contains(@data-id,'ignore_save')]"},
             { "Entity_FooterStatusField",".//span[contains(@role,'status')]"},
+            { "Entity_FooterMessage",".//span[contains(@data-id,'footer-message')]"},
             { "Entity_BooleanFieldRadioContainer", "//div[contains(@data-id, '[NAME].fieldControl-checkbox-container') and contains(@role,'radiogroup')]"},
             { "Entity_BooleanFieldRadioTrue", "//div[contains(@data-id, '[NAME].fieldControl-checkbox-containercheckbox-inner-second')]"},
             { "Entity_BooleanFieldRadioFalse", "//div[contains(@data-id, '[NAME].fieldControl-checkbox-containercheckbox-inner-first')]"},

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/Elements/Entity.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/Elements/Entity.cs
@@ -115,6 +115,16 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             return _client.GetStatusFromFooter();
         }
 
+        /// <summary>
+        /// Gets the value of the message, if present, from the footer
+        /// </summary>
+        /// <returns>Message from the footer of the entity record</returns>
+        /// <returns>NULL if no message present</returns>
+        public string GetFooterMessageValue()
+        {
+            return _client.GetMessageFromFooter();
+        }
+
         public IReadOnlyList<FormNotification> GetFormNotifications()
         {
             return _client.GetFormNotifications().Value;

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/Elements/Entity.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/Elements/Entity.cs
@@ -119,7 +119,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         /// Gets the value of the message, if present, from the footer
         /// </summary>
         /// <returns>Message from the footer of the entity record</returns>
-        /// <returns>NULL if no message present</returns>
+        /// <returns>String.empty if no message present</returns>
         public string GetFooterMessageValue()
         {
             return _client.GetMessageFromFooter();

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -2962,17 +2962,44 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         {
             return this.Execute(GetOptions($"Get Status value from footer"), driver =>
             {
-                if (!driver.HasElement(By.XPath(AppElements.Xpath[AppReference.Entity.EntityFooter])))
-                    throw new NotFoundException("Unable to find footer on the form");
+                IWebElement footer;
+                var footerExists = driver.TryFindElement(By.XPath(AppElements.Xpath[AppReference.Entity.EntityFooter]), out footer);
 
-                var footer = driver.FindElement(By.XPath(AppElements.Xpath[AppReference.Entity.EntityFooter]));
+                IWebElement status;
+                footer.TryFindElement(By.XPath(AppElements.Xpath[AppReference.Entity.FooterStatusValue]), out status);
 
-                var status = footer.FindElement(By.XPath(AppElements.Xpath[AppReference.Entity.FooterStatusValue]));
+                if (footerExists)
+                {
+                    if (String.IsNullOrEmpty(status.Text))
+                        return "unknown";
 
-                if (String.IsNullOrEmpty(status.Text))
-                    return "unknown";
+                    return status.Text;
+                }
+                else
+                    throw new NoSuchElementException("Unable to find the footer on the entity form");
+            });
+        }
 
-                return status.Text;
+        internal BrowserCommandResult<string> GetMessageFromFooter()
+        {
+            return this.Execute(GetOptions($"Get Message value from footer"), driver =>
+            {
+                IWebElement footer;
+                var footerExists = driver.TryFindElement(By.XPath(AppElements.Xpath[AppReference.Entity.EntityFooter]), out footer);
+
+                if (footerExists)
+                {
+                    IWebElement message;
+                    footer.TryFindElement(By.XPath(AppElements.Xpath[AppReference.Entity.FooterMessageValue]), out message);
+
+                    if (String.IsNullOrEmpty(message.Text))
+                        return string.Empty;
+
+                    return message.Text;
+                }
+                else
+                    throw new NoSuchElementException("Unable to find the footer on the entity form");
+
             });
         }
 


### PR DESCRIPTION
### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (updates to documentation, formatting, etc.)

### Description
- Added a new GetFooterMessageValue method
  - Will return string of the message value, or String.Empty if no message present
- Updated GetFooterStatusValue method to match behavior of new message method, return values not impacted

### All submissions:

- [X] My code follows the code style of this project.
- [ ] Do existing samples that are effected by this change still run?
- [ ] I have added samples for new functionality. 
- [X] I raise detailed error messages when possible.
- [X] My code does not rely on labels that have the option to be hidden.

### Which browsers was this tested on?
<!--- Should be tested on Chrome, Firefox, and IE. -->
- [X] Chrome
- [ ] Firefox
- [ ] IE
- [ ] Edge
