### PR TITLE
Add Support for Access "More Command" on RelatedGrid CommandBar

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/AppElementReference.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/AppElementReference.cs
@@ -258,6 +258,8 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         {
             public static string CommandBarButton = "Related_CommandBarButton";
             public static string CommandBarSubButton = "Related_CommandBarSubButton";
+            public static string CommandBarOverflowContainer = "Related_CommandBarOverflowContainer";
+            public static string CommandBarOverflowButton = "Related_CommandBarOverflowButton";
         }
 
         public static class Field
@@ -466,7 +468,9 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             { "BPF_CloseStageButton","//button[contains(@id,'stageContentClose')]"},
 
             //Related Grid
-            { "Related_CommandBarButton", "//button[contains(., '[NAME]') and contains(@data-id,'SubGrid')]"},
+            { "Related_CommandBarButton", "//button[contains(., '[NAME]') and contains(.,'SubGrid')]"},
+            { "Related_CommandBarOverflowContainer", "//li[contains(@id, '[NAME]') and contains(@id,'OverflowButton')]"},
+            { "Related_CommandBarOverflowButton", ".//button[contains(@data-id, 'OverflowButton')]"},
             { "Related_CommandBarSubButton" ,"//button[contains(., '[NAME]')]"},
 
             //Field

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/Elements/RelatedGrid.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/Elements/RelatedGrid.cs
@@ -29,9 +29,9 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         /// </summary>
         /// <param name="name">Name of the button to click</param>
         /// <param name="subName">Name of the submenu button to click</param>
-        public void ClickCommand(string name, string subName = null)
+        public void ClickCommand(string name, string subName = null, bool moreCommands = false, string gridName = null)
         {
-            _client.ClickRelatedCommand(name, subName);
+            _client.ClickRelatedCommand(name, subName, moreCommands, gridName);
         }
     }
 }

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -1629,28 +1629,75 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             });
         }
 
-        public BrowserCommandResult<bool> ClickRelatedCommand(string name, string subName = null)
+        public BrowserCommandResult<bool> ClickRelatedCommand(string name, string subName = null, bool moreCommands = false, string gridName = null)
         {
             return this.Execute(GetOptions("Click Related Tab Command"), driver =>
             {
-                if (!driver.HasElement(By.XPath(AppElements.Xpath[AppReference.Related.CommandBarButton].Replace("[NAME]", name))))
-                    throw new NotFoundException($"{name} button not found. Button names are case sensitive. Please check for proper casing of button name.");
-
-                driver.FindElement(By.XPath(AppElements.Xpath[AppReference.Related.CommandBarButton].Replace("[NAME]", name))).Click(true);
-
-                driver.WaitForTransaction();
-
-                if (subName != null)
+                //Look for Button
+                if (driver.HasElement(By.XPath(AppElements.Xpath[AppReference.Related.CommandBarButton].Replace("[NAME]", name))))
                 {
-                    if (!driver.HasElement(By.XPath(AppElements.Xpath[AppReference.Related.CommandBarSubButton].Replace("[NAME]", subName))))
-                        throw new NotFoundException($"{subName} button not found");
-
-                    driver.FindElement(By.XPath(AppElements.Xpath[AppReference.Related.CommandBarSubButton].Replace("[NAME]", subName))).Click(true);
+                    driver.FindElement(By.XPath(AppElements.Xpath[AppReference.Related.CommandBarButton].Replace("[NAME]", name))).Click(true);
 
                     driver.WaitForTransaction();
-                }
 
-                return true;
+                    if (subName != null)
+                    {
+                        if (!driver.HasElement(By.XPath(AppElements.Xpath[AppReference.Related.CommandBarSubButton].Replace("[NAME]", subName))))
+                            throw new NotFoundException($"{subName} button not found");
+
+                        driver.FindElement(By.XPath(AppElements.Xpath[AppReference.Related.CommandBarSubButton].Replace("[NAME]", subName))).Click(true);
+
+                        driver.WaitForTransaction();
+                    }
+
+                    return true;
+
+                }
+                else
+                {
+                    //Check if we should be looking under More Commands (OverflowButton)
+                    if (moreCommands && gridName != null)
+                    {
+                        if (driver.HasElement(By.XPath(AppElements.Xpath[AppReference.Related.CommandBarOverflowContainer].Replace("[NAME]", gridName)))) //Look for Button in Overflow
+                        {
+                            var Overflow = driver.FindElement(By.XPath(AppElements.Xpath[AppReference.Related.CommandBarOverflowContainer].Replace("[NAME]", gridName)));
+                            if (!Overflow.HasElement(By.XPath(AppElements.Xpath[AppReference.Related.CommandBarOverflowButton])))
+                                throw new NotFoundException($"{name} button not found. Button names are case sensitive. Please check for proper casing of button name.");
+                            Overflow.FindElement(By.XPath(AppElements.Xpath[AppReference.Related.CommandBarOverflowButton])).Click(true);
+
+                            if (driver.HasElement(By.XPath(AppElements.Xpath[AppReference.Related.CommandBarSubButton].Replace("[NAME]", name))))
+                            {
+                                driver.FindElement(By.XPath(AppElements.Xpath[AppReference.Related.CommandBarSubButton].Replace("[NAME]", name))).Click(true);
+
+                                driver.WaitForTransaction();
+
+                                if (subName != null)
+                                {
+                                    if (!driver.HasElement(By.XPath(AppElements.Xpath[AppReference.Related.CommandBarSubButton].Replace("[NAME]", subName))))
+                                        throw new NotFoundException($"{subName} button not found");
+
+                                    driver.FindElement(By.XPath(AppElements.Xpath[AppReference.Related.CommandBarSubButton].Replace("[NAME]", subName))).Click(true);
+
+                                    driver.WaitForTransaction();
+                                }
+
+                                return true;
+
+                            }
+                            return true;
+                        }
+                        else
+                        {
+                            throw new NotFoundException($"{name} button not found. Button names are case sensitive. Please check for proper casing of button name.");
+                        }
+
+                    }
+                    else
+                    {
+                        throw new NotFoundException($"{name} button not found. Button names are case sensitive. Please check for proper casing of button name.");
+                    }
+
+                }
             });
         }
 


### PR DESCRIPTION
### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (updates to documentation, formatting, etc.)

### Description
Depending on screen Resolution (and other factors) Buttons on SubGrids in Unified Interface could be hidden under the "More Command" ellipses (...) in which case RelatedGrid.ClickCommand would not find the Button. Extended the ClickCommand method to support searching for the button on a named RelatedGrid using xrmApp.RelatedGrid.ClickCommand("New Order", null, true, "Orders") for public void ClickCommand(string name, string subName = null, bool moreCommands = false, string gridName = null);

### Issues addressed
Depending on screen Resolution (and other factors) Buttons on SubGrids in Unified Interface could be hidden under the "More Command" ellipses (...) in which case RelatedGrid.ClickCommand would not find the Button. Extended the ClickCommand method to support searching for the button on a named RelatedGrid using xrmApp.RelatedGrid.ClickCommand("New Order", null, true, "Orders") for public void ClickCommand(string name, string subName = null, bool moreCommands = false, string gridName = null);

Possibly fixes https://github.com/microsoft/EasyRepro/issues/587


### All submissions:

- [x] My code follows the code style of this project.
- [x] Do existing samples that are effected by this change still run?
- [ ] I have added samples for new functionality. 
- [x] I raise detailed error messages when possible.
- [x] My code does not rely on labels that have the option to be hidden.

### Which browsers was this tested on?
<!--- Should be tested on Chrome, Firefox, and IE. -->
- [x] Chrome
- [ ] Firefox
- [ ] IE
- [ ] Edge
