### PR TITLE
PublishDialog, SetStateDialog, and GetFormNotifications fixes

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/AppElementReference.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/AppElementReference.cs
@@ -139,6 +139,8 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             public static string EntityOptionsetStatusComboButton = "Entity_OptionsetStatusComboButton";
             public static string EntityOptionsetStatusComboList = "Entity_OptionsetStatusComboList";
             public static string EntityOptionsetStatusTextValue = "Entity_OptionsetStatusTextValue";
+            public static string FormMessageBar = "Entity_FormMessageBar";
+            public static string FormMessageBarTypeIcon = "Entity_FormMessageBarTypeIcon";
             public static string FormNotifcationBar = "Entity_FormNotifcationBar";
             public static string FormNotifcationExpandButton = "Entity_FormNotifcationExpandButton";
             public static string FormNotifcationFlyoutRoot = "Entity_FormNotifcationFlyoutRoot";
@@ -234,10 +236,16 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             public static string AssignDialogOKButton = "AssignDialog_OKButton";
             public static string AssignDialogToggle = "AssignDialog_ToggleField";
             public static string ConfirmButton = "Dialog_ConfirmButton";
+            public static string CancelButton = "Dialog_CancelButton";
+            public static string PublishConfirmButton = "Dialog_PublishConfirmButton";
+            public static string PublishCancelButton = "Dialog_PublishCancelButton";
+            public static string SetStateDialog = "Dialog_SetStateDialog";
+            public static string SetStateActionButton = "Dialog_SetStateActionButton";
+            public static string SetStateCancelButton = "Dialog_SetStateCancelButton";
             public static string SwitchProcessDialog = "Entity_SwitchProcessDialog";
             public static string SwitchProcessDialogOK = "Entity_SwitchProcessDialogOK";
             public static string ActiveProcessGridControlContainer = "Entity_ActiveProcessGridControlContainer";
-            public static string CancelButton = "Dialog_CancelButton";
+
             public static string SwitchProcessContainer = "Dialog_SwitchProcessContainer";
         }
 
@@ -406,11 +414,13 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             { "Entity_OptionsetStatusComboButton", "//div[contains(@id, '[NAME].fieldControl-pickliststatus-comboBox_button')]"},
             { "Entity_OptionsetStatusComboList", "//ul[contains(@id, '[NAME].fieldControl-pickliststatus-comboBox_list')]"},
             { "Entity_OptionsetStatusTextValue", "//span[contains(@id, '[NAME].fieldControl-pickliststatus-comboBox_text-value')]"},
-            { "Entity_FormNotifcationBar", "//div[@data-id='notificationWrapper']" },
+            { "Entity_FormMessageBar", "//*[@id=\"notificationMessageAndButtons\"]/div/div/span" },
+            { "Entity_FormMessageBarTypeIcon", ".//span[contains(@data-id,'formReadOnlyIcon')]" },
+            { "Entity_FormNotifcationBar", "//div[contains(@data-id, 'notificationWrapper')]" },
+            { "Entity_FormNotifcationTypeIcon", ".//span[contains(@id,'notification_icon_')]" },            
             { "Entity_FormNotifcationExpandButton", ".//span[@id='notificationExpandIcon']" },
             { "Entity_FormNotifcationFlyoutRoot", "//div[@id='__flyoutRootNode']" },
             { "Entity_FormNotifcationList", ".//ul[@data-id='notificationList']" },
-            { "Entity_FormNotifcationTypeIcon", ".//span[contains(@id,'notification_icon_')]" },
 
             //Entity Header
             { "Entity_Header", "//div[contains(@data-id,'form-header')]"},
@@ -490,6 +500,11 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             { "Dialog_DescriptionId", "//input[contains(@data-id,'description_id')]" },
             { "Dialog_ConfirmButton" , "//*[@id=\"confirmButton\"]" },
             { "Dialog_CancelButton" , "//*[@id=\"cancelButton\"]" },
+            { "Dialog_SetStateDialog" , "//div[@data-id=\"SetStateDialog\"]" },
+            { "Dialog_SetStateActionButton" , ".//button[@data-id=\"ok_id\"]" },
+            { "Dialog_SetStateCancelButton" , ".//button[@data-id=\"cancel_id\"]" },
+            { "Dialog_PublishConfirmButton" , "//*[@data-id=\"ok_id\"]" },
+            { "Dialog_PublishCancelButton" , "//*[@data-id=\"cancel_id\"]" },
             { "Dialog_SwitchProcessContainer" , "//div[contains(@id,'switchProcess_id-FieldSectionItemContainer')]" },
             { "Entity_ActiveProcessGridControlContainer"       , "//div[contains(@data-lp-id,'activeProcessGridControlContainer')]"},
             { "Entity_SwitchProcessDialogOK"       , "//button[contains(@data-id,'ok_id')]"},

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/FormNotification.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/FormNotification.cs
@@ -9,7 +9,8 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI.DTO
         private static readonly Dictionary<string, FormNotificationType> _classToTypeMap = new Dictionary<string, FormNotificationType>{
             {"markaslost-symbol", FormNotificationType.Error},
             {"warning-symbol", FormNotificationType.Warning},
-            {"informationicon-symbol", FormNotificationType.Information}
+            {"informationicon-symbol", FormNotificationType.Information},
+            {"locked-symbol", FormNotificationType.Locked}
         };
 
 

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/FormNotificationType.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/FormNotificationType.cs
@@ -4,6 +4,7 @@
     {
         Information,
         Warning,
-        Error
+        Error,
+        Locked
     }
 }

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/Elements/Dialog.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/Elements/Dialog.cs
@@ -34,6 +34,27 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         }
 
         /// <summary>
+        /// Clicks OK or Cancel on the Set State (Activate / Deactivate) dialog.  true = OK, false = Cancel
+        /// </summary>
+        /// <param name="clickOkButton"></param>
+        /// <returns></returns>
+        public bool SetStateDialog(bool clickOkButton)
+        {
+            return _client.SetStateDialog(clickOkButton);
+        }
+
+        /// <summary>
+        /// Clicks Confirm or Cancel on the Publish dialog.  true = Confirm, false = Cancel
+        /// </summary>
+        /// <param name="clickOkButton"></param>
+        /// <returns></returns>
+        public bool PublishDialog(bool clickConfirmButton)
+        {
+            return _client.PublishDialog(clickConfirmButton);
+        }
+
+
+        /// <summary>
         /// Clicks Close As Won or Close As Loss on Opportunity Close dialog
         /// </summary>
         /// <param name="closeAsWon"></param>

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -915,6 +915,65 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             });
         }
 
+        internal BrowserCommandResult<bool> SetStateDialog(bool clickOkButton)
+        {
+            //Passing true clicks the Activate/Deactivate button.  Passing false clicks the Cancel button.
+            return this.Execute(GetOptions($"Interact with Set State Dialog"), driver =>
+            {
+                var inlineDialog = this.SwitchToDialog();
+                if (inlineDialog)
+                {
+                    //Wait until the buttons are available to click
+                    var dialog = driver.WaitUntilAvailable(By.XPath(AppElements.Xpath[AppReference.Dialogs.SetStateDialog]));
+
+                    if (
+                        !(dialog?.FindElements(By.TagName("button")).Count >
+                          0)) return true;
+
+                    //Click the Activate/Deactivate or Cancel button
+                    IWebElement buttonToClick;
+                    if (clickOkButton)
+                        buttonToClick = dialog.FindElement(By.XPath(AppElements.Xpath[AppReference.Dialogs.SetStateActionButton]));
+                    else
+                        buttonToClick = dialog.FindElement(By.XPath(AppElements.Xpath[AppReference.Dialogs.SetStateCancelButton]));
+
+                    buttonToClick.Click();
+                }
+
+                return true;
+            });
+        }
+
+        internal BrowserCommandResult<bool> PublishDialog(bool ClickConfirmButton)
+        {
+            //Passing true clicks the confirm button.  Passing false clicks the Cancel button.
+            return this.Execute(GetOptions($"Confirm or Cancel Publish Dialog"), driver =>
+            {
+                var inlineDialog = this.SwitchToDialog();
+                if (inlineDialog)
+                {
+                    //Wait until the buttons are available to click
+                    var dialogFooter = driver.WaitUntilAvailable(By.XPath(AppElements.Xpath[AppReference.Dialogs.PublishConfirmButton]));
+
+                    if (
+                        !(dialogFooter?.FindElements(By.XPath(AppElements.Xpath[AppReference.Dialogs.PublishConfirmButton])).Count >
+                          0)) return true;
+
+                    //Click the Confirm or Cancel button
+                    IWebElement buttonToClick;
+                    if (ClickConfirmButton)
+                        buttonToClick = dialogFooter.FindElement(By.XPath(AppElements.Xpath[AppReference.Dialogs.PublishConfirmButton]));
+                    else
+                        buttonToClick = dialogFooter.FindElement(By.XPath(AppElements.Xpath[AppReference.Dialogs.PublishCancelButton]));
+
+                    buttonToClick.Click();
+                }
+
+                return true;
+            });
+        }
+
+
         internal BrowserCommandResult<bool> AssignDialog(Dialogs.AssignTo to, string userOrTeamName = null)
         {
             userOrTeamName = userOrTeamName?.Trim() ?? string.Empty;
@@ -3437,37 +3496,70 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             {
                 List<FormNotification> notifications = new List<FormNotification>();
 
-                // Look for the notification bar, if it doesn't exist there are no notificatios
+                // Look for notificationMessageAndButtons bar
+                var notificationMessage = driver.WaitUntilAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.FormMessageBar]), TimeSpan.FromSeconds(2));
+
+                if (notificationMessage != null)
+                {
+                    IWebElement icon = null;
+
+                    try
+                    {
+                        icon = driver.FindElement(By.XPath(AppElements.Xpath[AppReference.Entity.FormMessageBarTypeIcon]));
+                    }
+                    catch(NoSuchElementException)
+                    {
+                        // Swallow the exception
+                    }
+
+                    if (icon != null)
+                    {
+                        var notification = new FormNotification
+                        {
+                            Message = notificationMessage?.Text
+                        };
+                        string classes = icon.GetAttribute("class");
+                        notification.SetTypeFromClass(classes);
+                        notifications.Add(notification);
+                    }
+                }
+
+                // Look for the notification wrapper, if it doesn't exist there are no notificatios
                 var notificationBar = driver.WaitUntilVisible(By.XPath(AppElements.Xpath[AppReference.Entity.FormNotifcationBar]), TimeSpan.FromSeconds(2));
                 if (notificationBar == null)
                     return notifications;
-
-                // If there are multiple notifications, the notifications must be expanded first.
-                if (notificationBar.TryFindElement(By.XPath(AppElements.Xpath[AppReference.Entity.FormNotifcationExpandButton]), out var expandButton))
+                else
                 {
-                    if (!Convert.ToBoolean(notificationBar.GetAttribute("aria-expanded")))
-                        expandButton.Click();
-
-                    // After expansion the list of notifications are now in a different element
-                    notificationBar = driver.WaitUntilAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.FormNotifcationFlyoutRoot]), TimeSpan.FromSeconds(2), "Failed to open the form notifications");
-                }
-
-                var notificationList = notificationBar.FindElement(By.XPath(AppElements.Xpath[AppReference.Entity.FormNotifcationList]));
-                var notificationListItems = notificationList.FindElements(By.TagName("li"));
-
-                foreach (var item in notificationListItems)
-                {
-                    var icon = item.FindElement(By.XPath(AppElements.Xpath[AppReference.Entity.FormNotifcationTypeIcon]));
-
-                    var notification = new FormNotification
+                    // If there are multiple notifications, the notifications must be expanded first.
+                    if (notificationBar.TryFindElement(By.XPath(AppElements.Xpath[AppReference.Entity.FormNotifcationExpandButton]), out var expandButton))
                     {
-                        Message = item.GetAttribute("aria-label")
-                    };
-                    string classes = icon.GetAttribute("class");
-                    notification.SetTypeFromClass(classes);
-                    notifications.Add(notification);
+                        if (!Convert.ToBoolean(notificationBar.GetAttribute("aria-expanded")))
+                            expandButton.Click();
+
+                        // After expansion the list of notifications are now in a different element
+                        notificationBar = driver.WaitUntilAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.FormNotifcationFlyoutRoot]), TimeSpan.FromSeconds(2), "Failed to open the form notifications");
+                    }
+
+                    var notificationList = notificationBar.FindElement(By.XPath(AppElements.Xpath[AppReference.Entity.FormNotifcationList]));
+                    var notificationListItems = notificationList.FindElements(By.TagName("li"));
+
+                    foreach (var item in notificationListItems)
+                    {
+                        var icon = item.FindElement(By.XPath(AppElements.Xpath[AppReference.Entity.FormNotifcationTypeIcon]));
+
+                        var notification = new FormNotification
+                        {
+                            Message = item.GetAttribute("aria-label")
+                        };
+                        string classes = icon.GetAttribute("class");
+                        notification.SetTypeFromClass(classes);
+                        notifications.Add(notification);
+                    }
+
+                    driver.ClearFocus(); // Close the Notification flyout
+
+                    return notifications;
                 }
-                return notifications;
 
             }).Value;
         }


### PR DESCRIPTION
### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Other (updates to documentation, formatting, etc.)

### Description
- Added new dialog method xrmApp.Dialogs.PublishDialog(bool clickConfirmButton);
- Added new dialog method xrmApp.Dialogs.SetStateDialog(bool ClickOkButton);
- Enhanced the method xrmApp.Entity.GetFormNotifications(); to include notification on record status (occurs when a record is Inactive)

### Issues addressed
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### All submissions:

- [x] My code follows the code style of this project.
- [ ] Do existing samples that are effected by this change still run?
- [ ] I have added samples for new functionality. 
- [x] I raise detailed error messages when possible.
- [x] My code does not rely on labels that have the option to be hidden.

### Which browsers was this tested on?
<!--- Should be tested on Chrome, Firefox, and IE. -->
- [x] Chrome
- [ ] Firefox
- [ ] IE
- [ ] Edge
