### PR TITLE
Update Entity_RecordSetNavList reference to the proper element

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/AppElementReference.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/AppElementReference.cs
@@ -365,7 +365,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             { "Entity_TextFieldLookupFieldContainer", "//div[@data-id='[NAME].fieldControl-Lookup_[NAME]']" },
             { "Entity_RecordSetNavigatorOpen", "//button[contains(@data-lp-id, 'recordset-navigator')]" },
             { "Entity_RecordSetNavigator", "//button[contains(@data-lp-id, 'recordset-navigator')]" },
-            { "Entity_RecordSetNavList", "//ul[contains(@data-id, 'recordSetNaveList')]" },
+            { "Entity_RecordSetNavList", "//ul[contains(@data-id, 'recordSetNavList')]" },
             { "Entity_RecordSetNavCollapseIcon", "//*[contains(@data-id, 'recordSetNavCollapseIcon')]" },
             { "Entity_RecordSetNavCollapseIconParent", "//*[contains(@data-id, 'recordSetNavCollapseIcon')]" },
             { "Entity_TabList", "//ul[@id=\"tablist\"]" },


### PR DESCRIPTION
### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (updates to documentation, formatting, etc.)

### Description
<!--- Describe your changes -->
Updated the AppElementReference to correct a typo:
FROM: { "Entity_RecordSetNavList", "//ul[contains(@data-id, 'recordSetNaveList')]" },
TO: { "Entity_RecordSetNavList", "//ul[contains(@data-id, 'recordSetNavList')]" },

### Issues addressed
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/microsoft/EasyRepro/issues/846

### All submissions:

- [X] My code follows the code style of this project.
- [X] Do existing samples that are effected by this change still run?
- [ ] I have added samples for new functionality. 
- [X] I raise detailed error messages when possible.
- [X] My code does not rely on labels that have the option to be hidden.

### Which browsers was this tested on?
<!--- Should be tested on Chrome, Firefox, and IE. -->
- [X] Chrome
- [ ] Firefox
- [ ] IE
- [ ] Edge
