### PR TITLE
GetBusinessProcessError method for Unified Interface

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/Elements/Entity.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/Elements/Entity.cs
@@ -107,6 +107,17 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         }
 
         /// <summary>
+        /// Gets test from a Business Process Error, if present
+        /// <paramref name="waitTimeInSeconds"/>Number of seconds to wait for the error dialog. Default value is 120 seconds</param>
+        /// </summary>
+        /// <example>var errorText = xrmApp.Entity.GetBusinessProcessError(int waitTimeInSeconds);</example>
+        public string GetBusinessProcessError(int waitTimeInSeconds = 120)
+        {
+            _client.Browser.Driver.WaitForTransaction();
+            return _client.GetBusinessProcessErrorText(waitTimeInSeconds);
+        }
+
+        /// <summary>
         /// Gets the value of the status from the footer
         /// </summary>
         /// <returns>Status of the entity record</returns>

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -1109,6 +1109,30 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             });
         }
 
+        internal BrowserCommandResult<string> GetBusinessProcessErrorText(int waitTimeInSeconds)
+        {
+
+            return this.Execute(GetOptions($"Get Business Process Error Text"), driver =>
+            {
+                string errorDetails = string.Empty;
+                var errorDialog = driver.WaitUntilAvailable(By.XPath("//div[contains(@data-id,'errorDialogdialog')]"), new TimeSpan(0, 0, waitTimeInSeconds));
+
+                // Is error dialog present?
+                if (errorDialog != null)
+                {
+                    var errorDetailsElement = errorDialog.FindElement(By.XPath(".//*[contains(@data-id,'errorDialog_subtitle')]"));
+
+                    if (errorDetailsElement != null)
+                    {
+                        if (!String.IsNullOrEmpty(errorDetailsElement.Text))
+                            errorDetails = errorDetailsElement.Text;
+                    }
+                }
+
+                return errorDetails;
+            });
+        }
+
         private static ICollection<IWebElement> GetListItems(IWebElement container, LookupItem control)
         {
             var name = control.Name;

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -2044,7 +2044,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 {
                     // Initialize the Header context
                     var formContext = driver.WaitUntilAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderContext]));
-                    fieldContainer = formContext.WaitUntilAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.TextFieldContainer].Replace("[NAME]", field)));
+                    fieldContainer = formContext.WaitUntilAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.TextFieldContainer].Replace("[NAME]", control.Name)));
                 }
 
 


### PR DESCRIPTION
### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (updates to documentation, formatting, etc.)

### Description
- Added a new method, Entity.GetBusinessProcessError(int waitTimeInSeconds); to check and retrieve business process error text
  - Returns string.Empty if none present

### All submissions:

- [x] My code follows the code style of this project.
- [x] Do existing samples that are effected by this change still run?
- [ ] I have added samples for new functionality. 
- [x] I raise detailed error messages when possible.
- [x] My code does not rely on labels that have the option to be hidden.

### Which browsers was this tested on?
<!--- Should be tested on Chrome, Firefox, and IE. -->
- [x] Chrome
- [ ] Firefox
- [ ] IE
- [ ] Edge
