### PR TITLE
Include field label as part of GetField() method

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/Controls/Field.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/Controls/Field.cs
@@ -50,6 +50,12 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         public string Name { get; set; }
 
         /// <summary>
+        /// Gets or sets the Label of the field.
+        /// </summary>
+        /// <value>The field label</value>
+        public string Label { get; set; }
+
+        /// <summary>
         /// Returns if the field is read only.
         /// </summary>
         public bool IsReadOnly

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/AppElementReference.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/AppElementReference.cs
@@ -76,6 +76,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             public static string HeaderContext = "Entity_HeaderContext";
             public static string Save = "Entity_Save";
             public static string TextFieldContainer = "Entity_TextFieldContainer";
+            public static string TextFieldLabel = "Entity_TextFieldLabel";
             public static string TextFieldValue = "Entity_TextFieldValue";
             public static string TextFieldLookup = "Entity_TextFieldLookup";
             public static string TextFieldLookupSearchButton = "Entity_TextFieldLookupSearchButton";
@@ -363,6 +364,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             { "Entity_Save"       , "//button[contains(@data-id, 'form-save-btn')]"},
             { "Entity_SwitchProcess"       , "//button[contains(@data-id,'SwitchProcess')]"},
             { "Entity_TextFieldContainer", ".//*[contains(@id, \'[NAME]-FieldSectionItemContainer\')]" },
+            { "Entity_TextFieldLabel", ".//label[contains(@id, \'[NAME]-field-label\')]" },
             { "Entity_TextFieldValue", ".//input[contains(@data-id, \'[NAME].fieldControl\')]" },
             { "Entity_TextFieldLookup", ".//*[contains(@id, \'systemuserview_id.fieldControl-LookupResultsDropdown')]" },
             { "Entity_TextFieldLookupSearchButton", ".//button[contains(@data-id, '[NAME].fieldControl-LookupResultsDropdown_[NAME]_search')]" },

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -2739,10 +2739,25 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         {
             return this.Execute(GetOptions($"Get Field"), driver =>
             {
-                Field returnField = new Field(driver.WaitUntilAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.TextFieldContainer].Replace("[NAME]", field))));
+                var fieldElement = driver.WaitUntilAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.TextFieldContainer].Replace("[NAME]", field)));
+                Field returnField = new Field(fieldElement);
                 returnField.Name = field;
 
-                returnField.containerElement.SendKeys(Keys.Escape);
+                IWebElement fieldLabel = null;
+                try
+                {
+                    fieldLabel = fieldElement.FindElement(By.XPath(AppElements.Xpath[AppReference.Entity.TextFieldLabel].Replace("[NAME]", field)));
+                }
+                catch (NoSuchElementException)
+                {
+                    // Swallow
+                }
+
+                if (fieldLabel != null)
+                {
+                    returnField.Label = fieldLabel.Text;
+                }
+
                 return returnField;
             });
         }


### PR DESCRIPTION
### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Other (updates to documentation, formatting, etc.)

### Description
<!--- Describe your changes -->
- Adding field Label to the GetField method return type
 - If Label is not available, then Label should be considered NULL

### Issues addressed
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Provides the ability to assert on a field Label, if desired

### All submissions:

- [x] My code follows the code style of this project.
- [x] Do existing samples that are effected by this change still run?
- [ ] I have added samples for new functionality. 
- [x] I raise detailed error messages when possible.
- [x] My code does not rely on labels that have the option to be hidden.

### Which browsers was this tested on?
<!--- Should be tested on Chrome, Firefox, and IE. -->
- [x] Chrome
- [ ] Firefox
- [ ] IE
- [ ] Edge
