### PR TITLE
Update DateTimeControl.cs

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/Controls/DateTimeControl.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/Controls/DateTimeControl.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 
         private string _timeAsString;
         public string TimeAsString { 
-            get =>  _timeAsString ?? (_timeAsString = string.IsNullOrWhiteSpace(TimeFormat) ? Value?.ToShortTimeString() : Value?.ToString(TimeFormat));
+            get =>  _timeAsString ?? (_timeAsString = string.IsNullOrWhiteSpace(TimeFormat) ? Value?.ToShortTimeString().ToUpper() : Value?.ToString(TimeFormat)).ToUpper();
             set => _timeAsString = value;
         }
     }


### PR DESCRIPTION
Dynamics 365 Expects time as AM/PM some regional settings send values as Am and Pm which causes a failure of the SetValue, forcing ToUpper() resolves this issue

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (updates to documentation, formatting, etc.)

### Description
Added ToUpper() method to DataTime Values

### Issues addressed
Dynamics 365 Expects time as AM/PM some regional settings send values as Am and Pm which causes a failure of the SetValue, forcing ToUpper() resolves this issue

### All submissions:

- [x] My code follows the code style of this project.
- [x] Do existing samples that are effected by this change still run?
- [ ] I have added samples for new functionality. 
- [ ] I raise detailed error messages when possible.
- [x] My code does not rely on labels that have the option to be hidden.

### Which browsers was this tested on?
<!--- Should be tested on Chrome, Firefox, and IE. -->
- [x] Chrome
- [ ] Firefox
- [ ] IE
- [ ] Edge
