### PR TITLE
Add FormContext to SetValue within Timeline controls to address #865

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/Elements/Timeline.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/Elements/Timeline.cs
@@ -31,10 +31,10 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         {
             _client.OpenAndClickPopoutMenu(Reference.Timeline.Popout, Reference.Timeline.PopoutAppointment, 4000);
             _client.ThinkTime(4000);
-            _client.SetValue(Elements.ElementId[Reference.Timeline.AppointmentSubject], subject);
-            _client.SetValue(Elements.ElementId[Reference.Timeline.AppointmentLocation], location);
-            _client.SetValue(Elements.ElementId[Reference.Timeline.AppointmentDescription], description);
-            _client.SetValue(Elements.ElementId[Reference.Timeline.AppointmentDuration], duration);
+            _client.SetValue(Elements.ElementId[Reference.Timeline.AppointmentSubject], subject, FormContextType.QuickCreate);
+            _client.SetValue(Elements.ElementId[Reference.Timeline.AppointmentLocation], location, FormContextType.QuickCreate);
+            _client.SetValue(Elements.ElementId[Reference.Timeline.AppointmentDescription], description, FormContextType.QuickCreate);
+            _client.SetValue(Elements.ElementId[Reference.Timeline.AppointmentDuration], duration, FormContextType.QuickCreate);
         }
 
         /// <summary>
@@ -131,10 +131,10 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         {
             _client.OpenAndClickPopoutMenu(Reference.Timeline.Popout, Reference.Timeline.PopoutPhoneCall, 4000);
             _client.ThinkTime(4000);
-            _client.SetValue(Elements.ElementId[Reference.Timeline.PhoneCallSubject], subject);
-            _client.SetValue(Elements.ElementId[Reference.Timeline.PhoneCallNumber], phoneNumber);
-            _client.SetValue(Elements.ElementId[Reference.Timeline.PhoneCallDescription], description);
-            _client.SetValue(Elements.ElementId[Reference.Timeline.PhoneCallDuration], duration);
+            _client.SetValue(Elements.ElementId[Reference.Timeline.PhoneCallSubject], subject, FormContextType.QuickCreate);
+            _client.SetValue(Elements.ElementId[Reference.Timeline.PhoneCallNumber], phoneNumber, FormContextType.QuickCreate);
+            _client.SetValue(Elements.ElementId[Reference.Timeline.PhoneCallDescription], description, FormContextType.QuickCreate);
+            _client.SetValue(Elements.ElementId[Reference.Timeline.PhoneCallDuration], duration, FormContextType.QuickCreate);
         }
 
         /// <summary>
@@ -155,9 +155,9 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         {
             _client.OpenAndClickPopoutMenu(Reference.Timeline.Popout, Reference.Timeline.PopoutTask, 4000);
             _client.ThinkTime(4000);
-            _client.SetValue(Elements.ElementId[Reference.Timeline.TaskSubject], subject);
-            _client.SetValue(Elements.ElementId[Reference.Timeline.TaskDescription], description);
-            _client.SetValue(Elements.ElementId[Reference.Timeline.TaskDuration], duration);
+            _client.SetValue(Elements.ElementId[Reference.Timeline.TaskSubject], subject, FormContextType.QuickCreate);
+            _client.SetValue(Elements.ElementId[Reference.Timeline.TaskDescription], description, FormContextType.QuickCreate);
+            _client.SetValue(Elements.ElementId[Reference.Timeline.TaskDuration], duration, FormContextType.QuickCreate);
         }
 
         /// <summary>


### PR DESCRIPTION
### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (updates to documentation, formatting, etc.)

### Description
<!--- Describe your changes -->
Update SetValue for the Timeline controls for Appointment, Task, and Phone Call to pass the FormContext of QuickCreate

### Issues addressed
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Issue #865 

### All submissions:

- [X] My code follows the code style of this project.
- [X] Do existing samples that are affected by this change still run?
![image](https://user-images.githubusercontent.com/34693792/82103827-2ff76200-96da-11ea-9c4b-62e77cd7cc27.png)

- [ ] I have added samples for new functionality. 
- [] I raise detailed error messages when possible.
- [ ] My code does not rely on labels that have the option to be hidden.

### Which browsers was this tested on?
<!--- Should be tested on Chrome, Firefox, and IE. -->
- [X] Chrome
- [ ] Firefox
- [ ] IE
- [ ] Edge
