### PR TITLE
Added option to set downloads folder path for chrome and firefox

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -1219,7 +1219,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                     else
                         throw new InvalidOperationException($"No sub command with the name '{subname}' exists inside of Commandbar.");
 
-                    if (!string.IsNullOrEmpty(subname))
+                    if (!string.IsNullOrEmpty(subSecondName))
                     {
                         var subSecondmenu = driver.WaitUntilAvailable(By.XPath(AppElements.Xpath[AppReference.CommandBar.MoreCommandsMenu]));
 

--- a/Microsoft.Dynamics365.UIAutomation.Browser/BrowserOptions.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Browser/BrowserOptions.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Browser
         public BrowserOptions()
         {
             this.DriversPath = Path.Combine(Directory.GetCurrentDirectory()); //, @"Drivers\");
+            this.DownloadsPath = null;
             this.BrowserType = BrowserType.IE;
             this.PageLoadTimeout = new TimeSpan(0, 3, 0);
             this.CommandTimeout = new TimeSpan(0, 10, 0);
@@ -53,6 +54,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Browser
         public BrowserType BrowserType { get; set; }
         public BrowserCredentials Credentials { get; set; }
         public string DriversPath { get; set; }
+        public string DownloadsPath { get; set; }
         public bool PrivateMode { get; set; }
         public bool CleanSession { get; set; }
         public TimeSpan PageLoadTimeout { get; set; }
@@ -199,9 +201,14 @@ namespace Microsoft.Dynamics365.UIAutomation.Browser
                 options.AddArgument("test-type=browser");
             }
 
+            if (!string.IsNullOrEmpty(DownloadsPath))
+            {
+                options.AddUserProfilePreference("download.default_directory", DownloadsPath);
+            }
+
             return options;
         }
-        
+
         public virtual InternetExplorerOptions ToInternetExplorer()
         {
 
@@ -226,18 +233,25 @@ namespace Microsoft.Dynamics365.UIAutomation.Browser
                 IgnoreZoomLevel = true,
                 EnablePersistentHover = true,
                 BrowserCommandLineArguments = this.PrivateMode ? "-private" : ""
-               
+
             };
-            
+
             return options;
         }
 
-        public  virtual FirefoxOptions ToFireFox()
+        public virtual FirefoxOptions ToFireFox()
         {
             var options = new FirefoxOptions()
             {
                 UseLegacyImplementation = false
             };
+
+            if (!string.IsNullOrEmpty(DownloadsPath))
+            {
+                options.SetPreference("browser.download.folderList", 2);
+                options.SetPreference("browser.download.dir", DownloadsPath);
+                options.SetPreference("browser.helperApps.neverAsk.saveToDisk", "text/csv,application/java-archive, application/x-msexcel,application/excel,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/x-excel,application/vnd.ms-excel,image/png,image/jpeg,text/html,text/plain,application/msword,application/xml,application/vnd.microsoft.portable-executable");
+            }
 
             return options;
         }


### PR DESCRIPTION
### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (updates to documentation, formatting, etc.)

### Description
Enhancement: Add an option to use custom downloads folder path instead of default configured
Bugfix: Not able to click submenu command from ribbon bar

### Issues addressed
Enhancement: It will allow to configure the downloads folder path
Bugfix: Not able to click submenu command from ribbon bar

### All submissions:

- [x] My code follows the code style of this project.
- [ ] Do existing samples that are effected by this change still run?
- [ ] I have added samples for new functionality. 
- [ ] I raise detailed error messages when possible.
- [ ] My code does not rely on labels that have the option to be hidden.

### Which browsers was this tested on?
<!--- Should be tested on Chrome, Firefox, and IE. -->
- [x] Chrome
- [x] Firefox
- [ ] IE
- [ ] Edge
