### PR TITLE
Fixes firefox customerror

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -46,7 +46,8 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         {
             return this.Execute(GetOptions("Initialize Unified Interface Modes"), driver =>
             {
-                driver.WaitForPageToLoad();
+                // Wait for main page to load before attempting this. If you don't do this it might still be authenticating and the URL will be wrong
+                WaitForMainPage();
 
                 var uri = driver.Url;
                 var queryParams = "&flags=easyreproautomation=true";
@@ -61,6 +62,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                     driver.Navigate().GoToUrl(testModeUri);
                 }
 
+                // Again wait for loading
                 WaitForMainPage();
 
                 return true;


### PR DESCRIPTION
### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (updates to documentation, formatting, etc.)

### Description
<!--- Describe your changes -->
In the InitializeModes it will retrieve the URL and then based on that URL assign flags. In Firefox it will most of the time not have finished authenticating causing the url to still be the authentication provider instead of the actual CE organization. This change will just wait until the main page is loaded and then execute the same logic.

### Issues addressed
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/microsoft/EasyRepro/issues/778

### All submissions:

- [X] My code follows the code style of this project.
- [X] Do existing samples that are effected by this change still run?
- [ ] I have added samples for new functionality. 
- [ ] I raise detailed error messages when possible.
- [X] My code does not rely on labels that have the option to be hidden.

### Which browsers was this tested on?
<!--- Should be tested on Chrome, Firefox, and IE. -->
- [X] Chrome
- [X] Firefox
- [ ] IE
- [ ] Edge
