### PR TITLE
Fixes 'ElementNotInteractable' when setting fields without label

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -2269,11 +2269,6 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 
                 SetInputValue(driver, input, value);
 
-                // Needed to transfer focus out of special fields (email or phone)
-                var label = fieldContainer.ClickIfVisible(By.TagName("label"));
-                if (label == null)
-                    fieldContainer.SendKeys(Keys.Escape);
-
                 return true;
             });
         }


### PR DESCRIPTION
### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (updates to documentation, formatting, etc.)

### Description
<!--- Describe your changes -->
When setting a value for a text field (both single and multiline) there is some extra code regarding focus. This always throws an ElementNotInteractableException. According to the comment above it is for special fields (phone/email).

I removed it, because it seems to no longer needed. I ran tests using fields with and without label. Both for normal and phone/email fields. Everything worked without the code that was removed.

### Issues addressed
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/microsoft/EasyRepro/issues/881

### All submissions:

- [X] My code follows the code style of this project.
- [X] Do existing samples that are effected by this change still run?
- [ ] I have added samples for new functionality. 
- [ ] I raise detailed error messages when possible.
- [ ] My code does not rely on labels that have the option to be hidden.

### Which browsers was this tested on?
<!--- Should be tested on Chrome, Firefox, and IE. -->
- [X] Chrome
- [X] Firefox
- [ ] IE
- [ ] Edge
