### PR TITLE
BooleanItem Update

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/AppElementReference.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/AppElementReference.cs
@@ -152,6 +152,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             public static string EntityBooleanFieldList = "Entity_BooleanFieldList";
             public static string EntityBooleanFieldFlipSwitchLink = "Entity_BooleanFieldFlipSwitchLink";
             public static string EntityBooleanFieldFlipSwitchContainer = "Entity_BooleanFieldFlipSwitchContainer";
+            public static string EntityBooleanFieldToggle = "Entity_BooleanFieldToggle";
             public static string EntityOptionsetStatusCombo = "Entity_OptionsetStatusCombo";
             public static string EntityOptionsetStatusComboButton = "Entity_OptionsetStatusComboButton";
             public static string EntityOptionsetStatusComboList = "Entity_OptionsetStatusComboList";
@@ -449,6 +450,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             { "Entity_BooleanFieldButton", "//div[contains(@data-id, '[NAME].fieldControl_container')]"},
             { "Entity_BooleanFieldButtonTrue", ".//label[contains(@class, 'first-child')]"},
             { "Entity_BooleanFieldButtonFalse", ".//label[contains(@class, 'last-child')]"},
+            { "Entity_BooleanFieldToggle", "//div[contains(@data-id, '[NAME].fieldControl-toggle-container')]"},
             { "Entity_OptionSetFieldContainer", ".//div[@data-id='[NAME].fieldControl-option-set-container']" },
             { "Entity_OptionsetStatusCombo", "//div[contains(@data-id, '[NAME].fieldControl-pickliststatus-comboBox')]"},
             { "Entity_OptionsetStatusComboButton", "//div[contains(@id, '[NAME].fieldControl-pickliststatus-comboBox_button')]"},

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -2588,6 +2588,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 var hasRadio = fieldContainer.HasElement(By.XPath(AppElements.Xpath[AppReference.Entity.EntityBooleanFieldRadioContainer].Replace("[NAME]", option.Name)));
                 var hasCheckbox = fieldContainer.HasElement(By.XPath(AppElements.Xpath[AppReference.Entity.EntityBooleanFieldCheckbox].Replace("[NAME]", option.Name)));
                 var hasList = fieldContainer.HasElement(By.XPath(AppElements.Xpath[AppReference.Entity.EntityBooleanFieldList].Replace("[NAME]", option.Name)));
+                var hasToggle = fieldContainer.HasElement(By.XPath(AppElements.Xpath[AppReference.Entity.EntityBooleanFieldToggle].Replace("[NAME]", option.Name)));
                 var hasFlipSwitch = fieldContainer.HasElement(By.XPath(AppElements.Xpath[AppReference.Entity.EntityBooleanFieldFlipSwitchLink].Replace("[NAME]", option.Name)));
 
                 // Need to validate whether control is FlipSwitch or Button
@@ -2595,6 +2596,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 var flipSwitch = hasFlipSwitch ? fieldContainer.TryFindElement(By.XPath(AppElements.Xpath[AppReference.Entity.EntityBooleanFieldFlipSwitchContainer].Replace("[NAME]", option.Name)), out flipSwitchContainer) : false;
                 var hasButton = flipSwitchContainer != null ? flipSwitchContainer.HasElement(By.XPath(AppElements.Xpath[AppReference.Entity.EntityBooleanFieldButtonTrue])) : false;
                 hasFlipSwitch = hasButton ? false : hasFlipSwitch; //flipSwitch and button have the same container reference, so if it has a button it is not a flipSwitch
+                hasFlipSwitch = hasToggle ? false : hasFlipSwitch; //flipSwitch and Toggle have the same container reference, so if it has a Toggle it is not a flipSwitch
 
                 if (hasRadio)
                 {
@@ -2634,6 +2636,17 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                         {
                             driver.ClickWhenAvailable(By.Id(unselectedOption.GetAttribute("id")));
                         }
+                    }
+                }
+                else if (hasToggle)
+                {
+                    var toggle = fieldContainer.FindElement(By.XPath(AppElements.Xpath[AppReference.Entity.EntityBooleanFieldToggle].Replace("[NAME]", option.Name)));
+                    var link = toggle.FindElement(By.TagName("button"));
+                    var value = bool.Parse(link.GetAttribute("aria-checked"));
+
+                    if (value != option.Value)
+                    {
+                        link.Click();
                     }
                 }
                 else if (hasFlipSwitch)

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -3241,6 +3241,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 var hasRadio = fieldContainer.HasElement(By.XPath(AppElements.Xpath[AppReference.Entity.EntityBooleanFieldRadioContainer].Replace("[NAME]", option.Name)));
                 var hasCheckbox = fieldContainer.HasElement(By.XPath(AppElements.Xpath[AppReference.Entity.EntityBooleanFieldCheckbox].Replace("[NAME]", option.Name)));
                 var hasList = fieldContainer.HasElement(By.XPath(AppElements.Xpath[AppReference.Entity.EntityBooleanFieldList].Replace("[NAME]", option.Name)));
+                var hasToggle = fieldContainer.HasElement(By.XPath(AppElements.Xpath[AppReference.Entity.EntityBooleanFieldToggle].Replace("[NAME]", option.Name)));
 
                 if (hasRadio)
                 {
@@ -3264,6 +3265,13 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                     {
                         check = int.Parse(selectedOption.GetAttribute("value")) == 1;
                     }
+                }
+                else if (hasToggle)
+                {
+                    var toggle = fieldContainer.FindElement(By.XPath(AppElements.Xpath[AppReference.Entity.EntityBooleanFieldToggle].Replace("[NAME]", option.Name)));
+                    var link = toggle.FindElement(By.TagName("button"));
+
+                    check = bool.Parse(link.GetAttribute("aria-checked"));
                 }
                 else
                     throw new InvalidOperationException($"Field: {option.Name} Does not exist");


### PR DESCRIPTION
### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Other (updates to documentation, formatting, etc.)

### Description
<!--- Describe your changes -->
Added Support for GetValue and SetValue for BooleanItems which use the Two Option Set 'Toggle' control.

### Issues addressed
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Two Option Sets using the 'Toggle' custom control would throw errors with GetValue and SetValue

### All submissions:

- [X] My code follows the code style of this project.
- [X] Do existing samples that are effected by this change still run?
- [ ] I have added samples for new functionality. 
- [X] I raise detailed error messages when possible.
- [X] My code does not rely on labels that have the option to be hidden.

### Which browsers was this tested on?
<!--- Should be tested on Chrome, Firefox, and IE. -->
- [X] Chrome
- [ ] Firefox
- [ ] IE
- [ ] Edge
