### PR TITLE
Fixed ClickSubGridCommand, so that clicking a button within a flyout works correctly.

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -1960,46 +1960,46 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                             }
                             else
                                 throw new InvalidOperationException($"No command with the name '{name}' exists inside of {subGridName} Commandbar.");
-
-                            if (subName != null)
-                            {
-                                // Locate the sub-button flyout if subName present
-                                overflowContainer = driver.FindElement(By.XPath(AppElements.Xpath[AppReference.Entity.SubGridOverflowContainer]));
-
-                                //Click the primary button, if found
-                                if (overflowContainer.HasElement(By.XPath(AppElements.Xpath[AppReference.Entity.SubGridOverflowButton].Replace("[NAME]", subName))))
-                                {
-                                    overflowContainer.FindElement(By.XPath(AppElements.Xpath[AppReference.Entity.SubGridOverflowButton].Replace("[NAME]", subName))).Click(true);
-                                    driver.WaitForTransaction();
-                                }
-                                else
-                                    throw new InvalidOperationException($"No command with the name '{subName}' exists under the {name} command inside of {subGridName} Commandbar.");
-
-                                // Check if we need to go to a 3rd level
-                                if (subSecondName != null)
-                                {
-                                    // Locate the sub-button flyout if subSecondName present
-                                    overflowContainer = driver.FindElement(By.XPath(AppElements.Xpath[AppReference.Entity.SubGridOverflowContainer]));
-
-                                    //Click the primary button, if found
-                                    if (overflowContainer.HasElement(By.XPath(AppElements.Xpath[AppReference.Entity.SubGridOverflowButton].Replace("[NAME]", subSecondName))))
-                                    {
-                                        overflowContainer.FindElement(By.XPath(AppElements.Xpath[AppReference.Entity.SubGridOverflowButton].Replace("[NAME]", subSecondName))).Click(true);
-                                        driver.WaitForTransaction();
-                                    }
-                                    else
-                                        throw new InvalidOperationException($"No command with the name '{subSecondName}' exists under the {subName} command inside of {name} on the {subGridName} SubGrid Commandbar.");
-                                }
-                            }
-
-                            return true;
                         }
                         else
                             throw new InvalidOperationException($"No command with the name '{name}' exists inside of {subGridName} CommandBar.");
                     }
-                }
 
-                return true;                                            
+                    if (subName != null)
+                    {
+                        // Locate the sub-button flyout if subName present
+                        var overflowContainer = driver.FindElement(By.XPath(AppElements.Xpath[AppReference.Entity.SubGridOverflowContainer]));
+
+                        //Click the primary button, if found
+                        if (overflowContainer.HasElement(By.XPath(AppElements.Xpath[AppReference.Entity.SubGridOverflowButton].Replace("[NAME]", subName))))
+                        {
+                            overflowContainer.FindElement(By.XPath(AppElements.Xpath[AppReference.Entity.SubGridOverflowButton].Replace("[NAME]", subName))).Click(true);
+                            driver.WaitForTransaction();
+                        }
+                        else
+                            throw new InvalidOperationException($"No command with the name '{subName}' exists under the {name} command inside of {subGridName} Commandbar.");
+
+                        // Check if we need to go to a 3rd level
+                        if (subSecondName != null)
+                        {
+                            // Locate the sub-button flyout if subSecondName present
+                            overflowContainer = driver.FindElement(By.XPath(AppElements.Xpath[AppReference.Entity.SubGridOverflowContainer]));
+
+                            //Click the primary button, if found
+                            if (overflowContainer.HasElement(By.XPath(AppElements.Xpath[AppReference.Entity.SubGridOverflowButton].Replace("[NAME]", subSecondName))))
+                            {
+                                overflowContainer.FindElement(By.XPath(AppElements.Xpath[AppReference.Entity.SubGridOverflowButton].Replace("[NAME]", subSecondName))).Click(true);
+                                driver.WaitForTransaction();
+                            }
+                            else
+                                throw new InvalidOperationException($"No command with the name '{subSecondName}' exists under the {subName} command inside of {name} on the {subGridName} SubGrid Commandbar.");
+                        }
+                    }
+                }
+                else
+                    throw new InvalidOperationException($"Unable to locate the Commandbar for the {subGrid} SubGrid.");
+
+                return true;
             });
         }
 


### PR DESCRIPTION
Previously, clicking a command in a flyout would only work if the flyout happened to be in the 'More Commands'/ellipsis of the subgrid commandbar, now it works regardless.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (updates to documentation, formatting, etc.)

### Description
Inside ClickSubGridCommand, moved section of code that looks at subName which previously only ran if the flyout was in the 'More Commands' element, so it runs under both scenarios.

### Issues addressed
Allows you to reliably click a command contained within a flyout.

### All submissions:

- [x] My code follows the code style of this project.
- [x] Do existing samples that are effected by this change still run?
- [ ] I have added samples for new functionality. 
- [x] I raise detailed error messages when possible.
- [x] My code does not rely on labels that have the option to be hidden.

### Which browsers was this tested on?
<!--- Should be tested on Chrome, Firefox, and IE. -->
- [x] Chrome
- [ ] Firefox
- [ ] IE
- [ ] Edge
