### PR TITLE
Fix race condition on AddNote

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -4605,13 +4605,15 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                     else
                     {
                         driver.SwitchTo().Frame(inputbox);
-                        driver.SwitchTo().Frame(0);
-                        var inputBoxBody = driver.FindElements(By.TagName("body"));
-                        inputBoxBody[0].Click(true);
-                        inputBoxBody[0].SendKeys(value);
 
-                        driver.SwitchTo().ParentFrame();
-                        driver.SwitchTo().ParentFrame();
+                        driver.WaitUntilAvailable(By.TagName("iframe"));
+                        driver.SwitchTo().Frame(0);
+
+                        var inputBoxBody = driver.WaitUntilAvailable(By.TagName("body"));
+                        inputBoxBody.Click(true);
+                        inputBoxBody.SendKeys(value);
+
+                        driver.SwitchTo().DefaultContent();
                     }
 
                     return true;


### PR DESCRIPTION
### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (updates to documentation, formatting, etc.)

### Issues addressed
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix a race condition with AddNote when trying to switch frames

### All submissions:

- [x] My code follows the code style of this project.
- [x] Do existing samples that are effected by this change still run?
- [ ] I have added samples for new functionality. 
- [ ] I raise detailed error messages when possible.
- [x] My code does not rely on labels that have the option to be hidden.

### Which browsers was this tested on?
<!--- Should be tested on Chrome, Firefox, and IE. -->
- [x] Chrome
- [ ] Firefox
- [ ] IE
- [ ] Edge
