### PR TITLE
Fixes issue with getting subgrid items (will properly cycle through l…

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -3493,6 +3493,10 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                             }
 
                             subGridRows.Add(item);
+
+                            // Flush Item and Cell Values To Get New Rows
+                            cellValues = new List<string>();
+                            item = new GridItem();
                         }
 
                     }
@@ -3539,6 +3543,10 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                             }
 
                             subGridRows.Add(item);
+
+                            // Flush Item and Cell Values To Get New Rows
+                            cellValues = new List<string>();
+                            item = new GridItem();
                         }
                     }
 
@@ -3593,6 +3601,10 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                             }
 
                             subGridRows.Add(item);
+
+                            // Flush Item and Cell Values To Get New Rows
+                            cellValues = new List<string>();
+                            item = new GridItem();
                         }
                     }
 


### PR DESCRIPTION
### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (updates to documentation, formatting, etc.)

### Description
When getting subgrid items, only the data values from the first row would be utilized

### Issues addressed
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Will ensure that data for each subgrid row is returned as expected.

### All submissions:

- [x] My code follows the code style of this project.
- [x] Do existing samples that are effected by this change still run?
- [ ] I have added samples for new functionality. 
- [ ] I raise detailed error messages when possible.
- [x] My code does not rely on labels that have the option to be hidden.

### Which browsers was this tested on?
<!--- Should be tested on Chrome, Firefox, and IE. -->
- [x] Chrome
- [ ] Firefox
- [ ] IE
- [ ] Edge
