### PR TITLE
Support buttons on Duplicate Detection Dialog in UCI

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/AppElementReference.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/AppElementReference.cs
@@ -257,6 +257,8 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             public static string AssignDialogToggle = "AssignDialog_ToggleField";
             public static string ConfirmButton = "Dialog_ConfirmButton";
             public static string CancelButton = "Dialog_CancelButton";
+            public static string DuplicateDetectionIgnoreSaveButton = "DuplicateDetectionDialog_IgnoreAndSaveButton";
+            public static string DuplicateDetectionCancelButton = "DuplicateDetectionDialog_CancelButton";
             public static string PublishConfirmButton = "Dialog_PublishConfirmButton";
             public static string PublishCancelButton = "Dialog_PublishCancelButton";
             public static string SetStateDialog = "Dialog_SetStateDialog";
@@ -547,6 +549,8 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             { "Dialog_DescriptionId", "//input[contains(@data-id,'description_id')]" },
             { "Dialog_ConfirmButton" , "//*[@id=\"confirmButton\"]" },
             { "Dialog_CancelButton" , "//*[@id=\"cancelButton\"]" },
+            { "DuplicateDetectionDialog_IgnoreAndSaveButton" , "//button[contains(@data-id, 'ignore_save')]" },
+            { "DuplicateDetectionDialog_CancelButton" , "//button[contains(@data-id, 'close_dialog')]" },
             { "Dialog_SetStateDialog" , "//div[@data-id=\"SetStateDialog\"]" },
             { "Dialog_SetStateActionButton" , ".//button[@data-id=\"ok_id\"]" },
             { "Dialog_SetStateCancelButton" , ".//button[@data-id=\"cancel_id\"]" },

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/Elements/Dialog.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/Elements/Dialog.cs
@@ -34,6 +34,16 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         }
 
         /// <summary>
+        /// Clicks 'Ignore And Save' or 'Cancel' on the Duplicate Detection dialog.  true = Ignore And Save, false = Cancel
+        /// </summary>
+        /// <param name="clickConfirmButton"></param>
+        /// <returns></returns>
+        public bool DuplicateDetection(bool clickSaveOrCancel)
+        {
+            return _client.DuplicateDetection(clickSaveOrCancel);
+        }
+
+        /// <summary>
         /// Clicks OK or Cancel on the Set State (Activate / Deactivate) dialog.  true = OK, false = Cancel
         /// </summary>
         /// <param name="clickOkButton"></param>

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -926,6 +926,50 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             });
         }
 
+        internal BrowserCommandResult<bool> DuplicateDetection(bool clickSaveOrCancel)
+        {
+            string operationType;
+
+            if (clickSaveOrCancel)
+            {
+                operationType = "Ignore and Save";
+            }
+            else
+                operationType = "Cancel";
+
+            //Passing true clicks the Ignore and Save button.  Passing false clicks the Cancel button.
+            return this.Execute(GetOptions($"{operationType} Duplicate Detection Dialog"), driver =>
+            {
+                var inlineDialog = this.SwitchToDialog();
+                if (inlineDialog)
+                {
+                    //Wait until the buttons are available to click
+                    var dialogFooter = driver.WaitUntilAvailable(By.XPath(AppElements.Xpath[AppReference.Dialogs.DuplicateDetectionIgnoreSaveButton]));
+
+                    if (
+                        !(dialogFooter?.FindElements(By.XPath(AppElements.Xpath[AppReference.Dialogs.DuplicateDetectionIgnoreSaveButton])).Count >
+                          0)) return true;
+
+                    //Click the Confirm or Cancel button
+                    IWebElement buttonToClick;
+                    if (clickSaveOrCancel)
+                        buttonToClick = dialogFooter.FindElement(By.XPath(AppElements.Xpath[AppReference.Dialogs.DuplicateDetectionIgnoreSaveButton]));
+                    else
+                        buttonToClick = dialogFooter.FindElement(By.XPath(AppElements.Xpath[AppReference.Dialogs.DuplicateDetectionCancelButton]));
+
+                    buttonToClick.Click();
+                }
+
+                if (clickSaveOrCancel)
+                {
+                    // Wait for Save before proceeding
+                    driver.WaitForTransaction();
+                }
+
+                return true;
+            });
+        }
+
         internal BrowserCommandResult<bool> SetStateDialog(bool clickOkButton)
         {
             //Passing true clicks the Activate/Deactivate button.  Passing false clicks the Cancel button.


### PR DESCRIPTION
### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (updates to documentation, formatting, etc.)

### Description
<!--- Describe your changes -->
Add base changes to support interaction with buttons on Duplicate Detection dialog. No support for the inline record grid at this time.

### Issues addressed
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Duplicate Detection dialog was previously a parity gap in Unified Interface

### All submissions:

- [X] My code follows the code style of this project.
- [ ] Do existing samples that are effected by this change still run?
- [ ] I have added samples for new functionality. 
- [x] I raise detailed error messages when possible.
- [x] My code does not rely on labels that have the option to be hidden.

### Which browsers was this tested on?
<!--- Should be tested on Chrome, Firefox, and IE. -->
- [x] Chrome
- [ ] Firefox
- [ ] IE
- [ ] Edge
