### PR TITLE
Changes to support GetField on BPF

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/AppElementReference.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/AppElementReference.cs
@@ -236,6 +236,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             public static string BusinessProcessFlowFieldName = "BPF_FieldName_UCI";
             public static string BusinessProcessFlowFormContext = "BPF_FormContext";
             public static string TextFieldContainer = "BPF_TextFieldContainer";
+            public static string TextFieldLabel = "BPF_TextFieldLabel";
             public static string BooleanFieldContainer = "BPF_BooleanFieldContainer";
             public static string DateTimeFieldContainer = "BPF_DateTimeFieldContainer";
             public static string FieldControlDateTimeInputUCI = "BPF_FieldControlDateTimeInputUCI";
@@ -521,6 +522,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             { "BPF_FieldName_UCI"     , "//input[contains(@id,'[NAME]')]" },
             { "BPF_FormContext"     , "//div[contains(@id, \'ProcessStageControl-processHeaderStageFlyoutInnerContainer\')]" },
             { "BPF_TextFieldContainer", ".//div[contains(@data-lp-id, \'header_process_[NAME]\')]" },
+            { "BPF_TextFieldLabel", "//label[contains(@id, \'header_process_[NAME]-field-label\')]" },
             { "BPF_BooleanFieldContainer", ".//input[contains(@data-id, \'header_process_[NAME].fieldControl-checkbox-toggle\')]" },
             { "BPF_DateTimeFieldContainer", ".//input[contains(@data-id, \'[NAME].fieldControl-date-time-input\')]" },
             { "BPF_FieldControlDateTimeInputUCI",".//input[contains(@data-id,'[FIELD].fieldControl-date-time-input')]" },

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/Elements/BusinessProcessFlow.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/Elements/BusinessProcessFlow.cs
@@ -15,6 +15,11 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             _client = client;
         }
 
+        public Field GetField(string field)
+        {
+            return _client.BPFGetField(field);
+        }
+
         /// <summary>
         /// Retrieves the value of a text field
         /// </summary>

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -4701,6 +4701,33 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 
         #region BusinessProcessFlow
 
+        internal BrowserCommandResult<Field> BPFGetField(string field)
+        {
+            return this.Execute(GetOptions($"Get Field"), driver =>
+            {
+                var fieldElement = driver.WaitUntilAvailable(By.XPath(AppElements.Xpath[AppReference.BusinessProcessFlow.TextFieldContainer].Replace("[NAME]", field)));
+                Field returnField = new Field(fieldElement);
+                returnField.Name = field;
+
+                IWebElement fieldLabel = null;
+                try
+                {
+                    fieldLabel = fieldElement.FindElement(By.XPath(AppElements.Xpath[AppReference.BusinessProcessFlow.TextFieldLabel].Replace("[NAME]", field)));
+                }
+                catch (NoSuchElementException)
+                {
+                    // Swallow
+                }
+
+                if (fieldLabel != null)
+                {
+                    returnField.Label = fieldLabel.Text;
+                }
+
+                return returnField;
+            });
+        }
+
         /// <summary>
         /// Set Value
         /// </summary>


### PR DESCRIPTION
### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (updates to documentation, formatting, etc.)

### Description
<!--- Describe your changes -->
Adding GetField(string fieldSchemaName) capability to BusinessProcessFlow

### Issues addressed
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Allow get on BPF fields

`xrmApp.BusinessProcessFlow.GetField(string fieldSchemaName);`


### All submissions:

- [x] My code follows the code style of this project.
- [x] Do existing samples that are effected by this change still run?
- [ ] I have added samples for new functionality. 
- [x] I raise detailed error messages when possible.
- [x] My code does not rely on labels that have the option to be hidden.

### Which browsers was this tested on?
<!--- Should be tested on Chrome, Firefox, and IE. -->
- [x] Chrome
- [ ] Firefox
- [ ] IE
- [ ] Edge
