### PR TITLE
IsReadOnly support for additional field types

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/Controls/Field.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/Controls/Field.cs
@@ -3,6 +3,7 @@
 
 using OpenQA.Selenium;
 using Microsoft.Dynamics365.UIAutomation.Browser;
+using System;
 
 namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 {
@@ -66,7 +67,31 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 {
                     var readOnly = containerElement.FindElement(By.XPath(AppElements.Xpath[AppReference.Field.ReadOnly]));
 
-                    if(readOnly.HasAttribute("readonly"))
+                    if (readOnly.HasAttribute("aria-readonly"))
+                    {
+                        // TwoOption / Text / Lookup Condition
+                        bool isReadOnly = Convert.ToBoolean(readOnly.GetAttribute("aria-readonly"));
+                        if (isReadOnly)
+                            return true;
+                    }
+                    else if (readOnly.HasAttribute("readonly"))
+                        return true;
+                }
+                else if (containerElement.HasElement(By.TagName("select")))
+                {
+                    // Option Set Condition
+                    var readOnlySelect = containerElement.FindElement(By.TagName("select"));
+
+                    if (readOnlySelect.HasAttribute("disabled"))
+                        return true;
+
+                }
+                else if (containerElement.HasElement(By.TagName("input")))
+                {
+                    // DateTime condition
+                    var readOnlyInput = containerElement.FindElement(By.TagName("input"));
+
+                    if (readOnlyInput.HasAttribute("disabled"))
                         return true;
                 }
 


### PR DESCRIPTION
### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (updates to documentation, formatting, etc.)

### Description
<!--- Describe your changes -->
Previoulsy the IsReadOnly property on GetField() required the aria-readonly class to exist. Not all field elements contain this class

### Issues addressed
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Allows for proper determination of IsReadOnly for additional field types

### All submissions:

- [x] My code follows the code style of this project.
- [x] Do existing samples that are effected by this change still run?
- [ ] I have added samples for new functionality. 
- [ ] I raise detailed error messages when possible.
- [x] My code does not rely on labels that have the option to be hidden.

### Which browsers was this tested on?
<!--- Should be tested on Chrome, Firefox, and IE. -->
- [x] Chrome
- [ ] Firefox
- [ ] IE
- [ ] Edge
