### PR TITLE
Added wait and extra sendkeys action to minimize '---' text being left

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -2333,6 +2333,8 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 
         private void SetInputValue(IWebDriver driver, IWebElement input, string value, TimeSpan? thinktime = null)
         {
+            driver.WaitForTransaction();
+            input.SendKeys(Keys.Control + "a");
             input.SendKeys(Keys.Control + "a");
             input.SendKeys(Keys.Backspace);
             driver.WaitForTransaction();


### PR DESCRIPTION
### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [ ] Other (updates to documentation, formatting, etc.)

### Description
<!--- Describe your changes -->

- Adding a wait and extra sendkeys action to try and minimize '---' text being left in a field unexpectedly

### Issues addressed
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In some scenarios, the placeholder text '---' may be left in a field resulting in unexpected text field data.

### All submissions:

- [x] My code follows the code style of this project.
- [x] Do existing samples that are effected by this change still run?
- [ ] I have added samples for new functionality. 
- [ ] I raise detailed error messages when possible.
- [x] My code does not rely on labels that have the option to be hidden.

### Which browsers was this tested on?
<!--- Should be tested on Chrome, Firefox, and IE. -->
- [x] Chrome
- [ ] Firefox
- [ ] IE
- [ ] Edge
