### PR TITLE
Check unique lookup style fields which present ReadOnly differently

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/Controls/Field.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/Controls/Field.cs
@@ -94,6 +94,17 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                     if (readOnlyInput.HasAttribute("disabled"))
                         return true;
                 }
+                else
+                {
+                    // Special Lookup Field condition (e.g. transactioncurrencyid)
+                    var lookupRecordList = containerElement.FindElement(By.XPath(AppElements.Xpath[AppReference.Lookup.RecordList]));
+                    var lookupDescription = lookupRecordList.FindElement(By.TagName("div"));
+
+                    if (lookupDescription != null)
+                        return lookupDescription.GetAttribute("innerText").ToLowerInvariant().Contains("readonly", StringComparison.OrdinalIgnoreCase);                   
+                    else
+                        return false;                    
+                }
 
                 return false;
             }

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/AppElementReference.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/AppElementReference.cs
@@ -292,6 +292,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             public static string ViewRows = "Lookup_ViewRows";
             public static string LookupResultRows = "Lookup_ResultRows";
             public static string NewButton = "Lookup_NewButton";
+            public static string RecordList = "Lookup_RecordList";
         }
 
         public static class Related
@@ -583,6 +584,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             { "Lookup_ViewRows", "//li[contains(@data-id,'viewLineContainer')]"},
             { "Lookup_ResultRows", "//li[contains(@data-id,'LookupResultsDropdown') and contains(@data-id,'resultsContainer')]"},
             { "Lookup_NewButton", "//button[contains(@data-id,'addNewBtnContainer') and contains(@data-id,'LookupResultsDropdown')]" },
+            { "Lookup_RecordList", ".//div[contains(@id,'RecordList') and contains(@role,'presentation')]" },
 
             //Performance Width
             { "Performance_Widget","//div[@data-id='performance-widget']/div"},

--- a/Microsoft.Dynamics365.UIAutomation.Browser/Constants.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Browser/Constants.cs
@@ -97,7 +97,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Browser
                 ".crm.dynamics.com", ".crm2.dynamics.com", ".crm3.dynamics.com",
                 ".crm4.dynamics.com", "crm5.dynamics.com", "crm6.dynamics.com", "crm7.dynamics.com",
                 ".crm8.dynamics.com", ".crm9.dynamics.com", ".crm10.dynamics.com", ".crm11.dynamics.com",
-                ".crm12.dynamics.com", "portal.office.com", "crm2.crmlivetie.com"
+                ".crm12.dynamics.com", ".crm15.dynamics.com", "portal.office.com", "crm2.crmlivetie.com", ".crm.microsoftdynamics.us", "portal.office365.us"
             };
         }
 


### PR DESCRIPTION
### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (updates to documentation, formatting, etc.)

### Description
<!--- Describe your changes -->
- Add support for unique lookup fields (e.g transactioncurrencyid) which present differently details for IsReadOnly
- Add support for UAE region in XrmDomains

### Issues addressed
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- Properly return IsReadOnly value for this special lookup field type

### All submissions:

- [x] My code follows the code style of this project.
- [x] Do existing samples that are effected by this change still run?
- [ ] I have added samples for new functionality. 
- [x] I raise detailed error messages when possible.
- [x] My code does not rely on labels that have the option to be hidden.

### Which browsers was this tested on?
<!--- Should be tested on Chrome, Firefox, and IE. -->
- [x] Chrome
- [ ] Firefox
- [ ] IE
- [ ] Edge
