### PR TITLE
Fixes for setting DateTime fields in Header

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -2696,13 +2696,6 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             TrySetDateValue(driver, container, control, formContext);
             TrySetTime(driver, container, control, formContext);
 
-            if (container is IWebElement parent)
-            {
-                parent.Click(true);
-                parent.SendKeys(Keys.Escape); // Close Calendar
-                parent.SendKeys(Keys.Escape); // Close Header control
-            }
-
             TryCloseHeaderFlyout(driver);
 
             return true;
@@ -2790,27 +2783,27 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 //IWebDriver formContext;
                 // Initialize the quick create form context
                 // If this is not done -- element input will go to the main form due to new flyout design
-                formContext = container.WaitUntilAvailable(By.XPath(AppElements.Xpath[AppReference.QuickCreate.QuickCreateFormContext]));
+                formContext = container.WaitUntilAvailable(By.XPath(AppElements.Xpath[AppReference.QuickCreate.QuickCreateFormContext]), new TimeSpan(0,0, 1));
             }
             else if (formContextType == FormContextType.Entity)
             {
                 // Initialize the entity form context
-                formContext = container.WaitUntilAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.FormContext]));
+                formContext = container.WaitUntilAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.FormContext]), new TimeSpan(0, 0, 1));
             }
             else if (formContextType == FormContextType.BusinessProcessFlow)
             {
                 // Initialize the Business Process Flow context
-                formContext = container.WaitUntilAvailable(By.XPath(AppElements.Xpath[AppReference.BusinessProcessFlow.BusinessProcessFlowFormContext]));
+                formContext = container.WaitUntilAvailable(By.XPath(AppElements.Xpath[AppReference.BusinessProcessFlow.BusinessProcessFlowFormContext]), new TimeSpan(0, 0, 1));
             }
             else if (formContextType == FormContextType.Header)
             {
                 // Initialize the Header context
-                formContext = container.WaitUntilAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderContext]));
+                formContext = container as IWebElement;
             }
             else if (formContextType == FormContextType.Dialog)
             {
                 // Initialize the Header context
-                formContext = container.WaitUntilAvailable(By.XPath(AppElements.Xpath[AppReference.Dialogs.DialogContext]));
+                formContext = container.WaitUntilAvailable(By.XPath(AppElements.Xpath[AppReference.Dialogs.DialogContext]), new TimeSpan(0, 0, 1));
             }
 
             var success = formContext.TryFindElement(timeFieldXPath, out var timeField);
@@ -2831,6 +2824,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 timeField.Click();
                 timeField.SendKeys(time);
                 timeField.SendKeys(Keys.Tab);
+                driver.WaitForTransaction();
             },
                 d => timeField.GetAttribute("value").IsValueEqualsTo(time),
                 TimeSpan.FromSeconds(9), 3,

--- a/Microsoft.Dynamics365.UIAutomation.Browser/Extensions/SeleniumExtensions.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Browser/Extensions/SeleniumExtensions.cs
@@ -428,8 +428,18 @@ namespace Microsoft.Dynamics365.UIAutomation.Browser
 
         public static bool TryFindElement(this ISearchContext context, By by, out IWebElement element)
         {
-            var elements = context.FindElements(by);
-            var success = elements.Count > 0;
+            ReadOnlyCollection<IWebElement> elements = null;
+
+            try
+            {
+               elements = context.FindElements(by);
+            }
+            catch (NullReferenceException)
+            {
+                // Do nothing
+            }
+
+            var success = elements?.Count > 0;
             element = success ? elements[0] : null;
             return success;
         }


### PR DESCRIPTION
### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (updates to documentation, formatting, etc.)

### Description
<!--- Describe your changes -->

- Adjustments to Entity.SetHeaderValue(string field, DateTime date, string formatDate = null, string formatTime = null)
   - Adjusted header context
   - Catch Null reference and ignore if Time field doesn't exist
   - Limit WaitUntilAvailable call for Time field check to 1 second 

### Issues addressed
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- Fix problems with Entity.SetHeaderValue for date fields if time control is not present
- Resiliency changes when setting time control value

### All submissions:

- [x] My code follows the code style of this project.
- [x] Do existing samples that are effected by this change still run?
- [ ] I have added samples for new functionality. 
- [ ] I raise detailed error messages when possible.
- [x] My code does not rely on labels that have the option to be hidden.

### Which browsers was this tested on?
<!--- Should be tested on Chrome, Firefox, and IE. -->
- [x] Chrome
- [ ] Firefox
- [ ] IE
- [ ] Edge
