### PR TITLE
Fixes for checking GetField().IsRequired on BPF

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/Controls/Field.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/Controls/Field.cs
@@ -117,11 +117,11 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         {
             get
             {
-                if (containerElement.HasElement(By.XPath(AppElements.Xpath[AppReference.Field.Required])))
+                if (containerElement.HasElement(By.XPath(AppElements.Xpath[AppReference.Field.RequiredIcon])))
                 {
-                    var required = containerElement.FindElement(By.XPath(AppElements.Xpath[AppReference.Field.Required]));
+                    var required = containerElement.FindElement(By.XPath(AppElements.Xpath[AppReference.Field.RequiredIcon]));
 
-                    if (required.GetAttribute("aria-required") == "true")
+                    if (required != null)
                         return true;
                 }
 

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/AppElementReference.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/AppElementReference.cs
@@ -236,6 +236,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             public static string BusinessProcessFlowFieldName = "BPF_FieldName_UCI";
             public static string BusinessProcessFlowFormContext = "BPF_FormContext";
             public static string TextFieldContainer = "BPF_TextFieldContainer";
+            public static string FieldSectionItemContainer = "BPF_FieldSectionItemContainer";
             public static string TextFieldLabel = "BPF_TextFieldLabel";
             public static string BooleanFieldContainer = "BPF_BooleanFieldContainer";
             public static string DateTimeFieldContainer = "BPF_DateTimeFieldContainer";
@@ -308,6 +309,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         {
             public static string ReadOnly = "Field_ReadOnly";
             public static string Required = "Field_Required";
+            public static string RequiredIcon = "Field_RequiredIcon";
         }
         public static class PerformanceWidget
         {
@@ -526,6 +528,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             { "BPF_NextStageButton_UCI"     , "//button[contains(@data-id,'nextButtonContainer')]" },
             { "BPF_SetActiveButton", "//button[contains(@data-id,'setActiveButton')]" },
             { "BPF_FieldName_UCI"     , "//input[contains(@id,'[NAME]')]" },
+            { "BPF_FieldSectionItemContainer", ".//div[contains(@id, \'header_process_[NAME]-FieldSectionItemContainer\')]" },
             { "BPF_FormContext"     , "//div[contains(@id, \'ProcessStageControl-processHeaderStageFlyoutInnerContainer\')]" },
             { "BPF_TextFieldContainer", ".//div[contains(@data-lp-id, \'header_process_[NAME]\')]" },
             { "BPF_TextFieldLabel", "//label[contains(@id, \'header_process_[NAME]-field-label\')]" },
@@ -545,6 +548,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             //Field
             {"Field_ReadOnly",".//*[@aria-readonly]" },
             {"Field_Required", ".//*[@aria-required]"},
+            {"Field_RequiredIcon", ".//div[contains(@data-id, 'required-icon') or contains(@id, 'required-icon')]"},
 
             //Dialogs
             { "AssignDialog_ToggleField" , "//label[contains(@data-id,'rdoMe_id.fieldControl-checkbox-inner-first')]" },

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/Microsoft.Dynamics365.UIAutomation.Api.UCI.csproj
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/Microsoft.Dynamics365.UIAutomation.Api.UCI.csproj
@@ -23,6 +23,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>7.2</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -31,6 +32,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>7.2</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.ApplicationInsights, Version=2.11.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -113,6 +115,10 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\Microsoft.Dynamics365.UIAutomation.Api\Microsoft.Dynamics365.UIAutomation.Api.csproj">
+      <Project>{dfe2c141-f1aa-4d4b-8df8-0fb93023cf45}</Project>
+      <Name>Microsoft.Dynamics365.UIAutomation.Api</Name>
+    </ProjectReference>
     <ProjectReference Include="..\Microsoft.Dynamics365.UIAutomation.Browser\Microsoft.Dynamics365.UIAutomation.Browser.csproj">
       <Project>{c9748803-f3cb-4531-b313-bc24d4d0bf0c}</Project>
       <Name>Microsoft.Dynamics365.UIAutomation.Browser</Name>

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -4742,7 +4742,10 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         {
             return this.Execute(GetOptions($"Get Field"), driver =>
             {
-                var fieldElement = driver.WaitUntilAvailable(By.XPath(AppElements.Xpath[AppReference.BusinessProcessFlow.TextFieldContainer].Replace("[NAME]", field)));
+
+                // Initialize the Business Process Flow context
+                var formContext = driver.WaitUntilAvailable(By.XPath(AppElements.Xpath[AppReference.BusinessProcessFlow.BusinessProcessFlowFormContext]));
+                var fieldElement = formContext.WaitUntilAvailable(By.XPath(AppElements.Xpath[AppReference.BusinessProcessFlow.FieldSectionItemContainer].Replace("[NAME]", field)));                
                 Field returnField = new Field(fieldElement);
                 returnField.Name = field;
 

--- a/Microsoft.Dynamics365.UIAutomation.Api/Microsoft.Dynamics365.UIAutomation.Api.csproj
+++ b/Microsoft.Dynamics365.UIAutomation.Api/Microsoft.Dynamics365.UIAutomation.Api.csproj
@@ -23,6 +23,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>7.2</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -31,6 +32,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>7.2</LangVersion>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>false</SignAssembly>

--- a/Microsoft.Dynamics365.UIAutomation.Browser/Microsoft.Dynamics365.UIAutomation.Browser.csproj
+++ b/Microsoft.Dynamics365.UIAutomation.Browser/Microsoft.Dynamics365.UIAutomation.Browser.csproj
@@ -23,6 +23,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>7.2</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -31,6 +32,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>7.2</LangVersion>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>false</SignAssembly>

--- a/Microsoft.Dynamics365.UIAutomation.Sample/Microsoft.Dynamics365.UIAutomation.Sample.csproj
+++ b/Microsoft.Dynamics365.UIAutomation.Sample/Microsoft.Dynamics365.UIAutomation.Sample.csproj
@@ -28,6 +28,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>7.2</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -36,6 +37,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>7.2</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.ApplicationInsights, Version=2.11.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">


### PR DESCRIPTION
### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (updates to documentation, formatting, etc.)

### Description
<!--- Describe your changes -->

- GetField().IsRequired was always returning false. These changes allow determination of IsRequired for BusinessProcessFlow 
 fields

### Issues addressed
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- GetField().IsRequired will properly return True/False depending on field required state for BusinessProcessFlow fields

### All submissions:

- [x] My code follows the code style of this project.
- [x] Do existing samples that are effected by this change still run?
- [ ] I have added samples for new functionality. 
- [ ] I raise detailed error messages when possible.
- [x] My code does not rely on labels that have the option to be hidden.

### Which browsers was this tested on?
<!--- Should be tested on Chrome, Firefox, and IE. -->
- [x] Chrome
- [ ] Firefox
- [ ] IE
- [ ] Edge
