### PR TITLE
Dialog SetValue OptionSet race condition fix

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -2516,6 +2516,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 fieldContainer = ValidateFormContext(driver, formContextType, controlName, fieldContainer);
 
                 TrySetValue(fieldContainer, control);
+                driver.WaitForTransaction();
                 return true;
             });
         }

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -2526,6 +2526,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             bool success = fieldContainer.TryFindElement(By.TagName("select"), out IWebElement select);
             if (success)
             {
+                fieldContainer.WaitUntilAvailable(By.TagName("select"));
                 var options = select.FindElements(By.TagName("option"));
                 SelectOption(options, value);
                 return;


### PR DESCRIPTION
### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (updates to documentation, formatting, etc.)

### Description
<!--- Describe your changes -->

- Seeing intermittent race condition scenarios where trying to SetValue(OptionSet) on a Dialog was incurring a null reference exception.

### Issues addressed
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- Introduce minor wait patterns to alleviate race condition

### All submissions:

- [x] My code follows the code style of this project.
- [x] Do existing samples that are effected by this change still run?
- [ ] I have added samples for new functionality. 
- [ ] I raise detailed error messages when possible.
- [x] My code does not rely on labels that have the option to be hidden.

### Which browsers was this tested on?
<!--- Should be tested on Chrome, Firefox, and IE. -->
- [x] Chrome
- [ ] Firefox
- [ ] IE
- [ ] Edge
