### PR TITLE
Honour `BrowserOptions.CommandTimeout`

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Browser/BrowserDriverFactory.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Browser/BrowserDriverFactory.cs
@@ -23,12 +23,12 @@ namespace Microsoft.Dynamics365.UIAutomation.Browser
                 case BrowserType.Chrome:
                     var chromeService = ChromeDriverService.CreateDefaultService(options.DriversPath);
                     chromeService.HideCommandPromptWindow = options.HideDiagnosticWindow;
-                    driver = new ChromeDriver(chromeService, options.ToChrome());
+                    driver = new ChromeDriver(chromeService, options.ToChrome(), options.CommandTimeout);
                     break;
                 case BrowserType.IE:
                     var ieService = InternetExplorerDriverService.CreateDefaultService(options.DriversPath);
                     ieService.SuppressInitialDiagnosticInformation = options.HideDiagnosticWindow;
-                    driver = new InternetExplorerDriver(ieService, options.ToInternetExplorer(), TimeSpan.FromMinutes(20));
+                    driver = new InternetExplorerDriver(ieService, options.ToInternetExplorer(), options.CommandTimeout);
                     break;
                 case BrowserType.Firefox:
                     var ffService = FirefoxDriverService.CreateDefaultService(options.DriversPath);
@@ -39,7 +39,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Browser
                 case BrowserType.Edge:
                     var edgeService = EdgeDriverService.CreateDefaultService(options.DriversPath);
                     edgeService.HideCommandPromptWindow = options.HideDiagnosticWindow;
-                    driver = new EdgeDriver(edgeService,options.ToEdge(), TimeSpan.FromMinutes(20));
+                    driver = new EdgeDriver(edgeService, options.ToEdge(), options.CommandTimeout);
                     break;
                 case BrowserType.Remote:
                     ICapabilities capabilities = null;
@@ -52,7 +52,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Browser
                             capabilities = options.ToFireFox().ToCapabilities();
                             break;
                     }
-                    driver = new RemoteWebDriver(options.RemoteHubServer, capabilities, TimeSpan.FromMinutes(20));
+                    driver = new RemoteWebDriver(options.RemoteHubServer, capabilities, options.CommandTimeout);
                     break;
                 default:
                     throw new InvalidOperationException(

--- a/Microsoft.Dynamics365.UIAutomation.Browser/BrowserOptions.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Browser/BrowserOptions.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Browser
             this.DownloadsPath = null;
             this.BrowserType = BrowserType.IE;
             this.PageLoadTimeout = new TimeSpan(0, 3, 0);
-            this.CommandTimeout = new TimeSpan(0, 10, 0);
+            this.CommandTimeout = TimeSpan.FromMinutes(20);
             this.StartMaximized = true;
             this.FireEvents = false;
             this.TraceSource = Constants.DefaultTraceSource;

--- a/Microsoft.Dynamics365.UIAutomation.Browser/BrowserOptions.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Browser/BrowserOptions.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Browser
         public bool PrivateMode { get; set; }
         public bool CleanSession { get; set; }
         public TimeSpan PageLoadTimeout { get; set; }
-        public TimeSpan CommandTimeout { get; set; }
+        public TimeSpan CommandTimeout { get; set; } = TimeSpan.FromMinutes(20);
         /// <summary>
         /// When <see langword="true" /> the browser will open maximized at the highest supported resolution.
         /// </summary>


### PR DESCRIPTION
### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (updates to documentation, formatting, etc.)

### Description
Honour the `BrowserOptions.CommandTimeout` option in Web Driver initialisation. This option was previously unused, so should not introduce any breaking change in behaviour as far as I know.

### Issues addressed
When constructing a `RemoteWebDriver` (from which all drivers derive e.g [ChromiumDriver](https://github.com/SeleniumHQ/selenium/blob/941dc9c6b2e2aa4f701c1b72be8de03d4b7e996a/dotnet/src/webdriver/Chromium/ChromiumDriver.cs#L34), [IEDriver](https://github.com/SeleniumHQ/selenium/blob/941dc9c6b2e2aa4f701c1b72be8de03d4b7e996a/dotnet/src/webdriver/IE/InternetExplorerDriver.cs#L64), [FirefoxDriver](https://github.com/SeleniumHQ/selenium/blob/941dc9c6b2e2aa4f701c1b72be8de03d4b7e996a/dotnet/src/webdriver/Firefox/FirefoxDriver.cs#L68)) using one of the constructor overloads without the [commandTimeout](https://github.com/SeleniumHQ/selenium/blob/941dc9c6b2e2aa4f701c1b72be8de03d4b7e996a/dotnet/src/webdriver/Remote/RemoteWebDriver.cs#L116) parameter, the default HTTP Command Timeout for the driver [defaults to 60 seconds](https://github.com/SeleniumHQ/selenium/blob/941dc9c6b2e2aa4f701c1b72be8de03d4b7e996a/dotnet/src/webdriver/Remote/RemoteWebDriver.cs#L69).

When performing long-running Dynamics 365 tests using `BrowserType.Chrome`, this can result in infrequent (~1 in 70), sporadic errors, usually when first navigating to the Dynamics 365 instance URL:
> The HTTP request to the remote WebDriver server for URL http://localhost:6634/session timed out after 60 seconds

This change allows a `CommandTimeout` in a supplied `BrowserOptions` instance to be used by the underlying Web Driver. This change also updates `ChromeDriver` to match the custom timeout of 20 minutes already used for `InternetExplorerDriver`, `EdgeDriver` and `RemoteWebDriver` which appears to similarly address this timeout issue.

### All submissions:

- [x] My code follows the code style of this project.
- [ ] Do existing samples that are effected by this change still run?
- [ ] I have added samples for new functionality. 
- [ ] I raise detailed error messages when possible.
- [ ] My code does not rely on labels that have the option to be hidden.

### Which browsers was this tested on?
<!--- Should be tested on Chrome, Firefox, and IE. -->
- [ ] Chrome
- [ ] Firefox
- [ ] IE
- [ ] Edge
