### PR TITLE
updated TrySetValue to check for FormContextType

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -2699,7 +2699,10 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             TrySetDateValue(driver, container, control, formContext);
             TrySetTime(driver, container, control, formContext);
 
-            TryCloseHeaderFlyout(driver);
+            if (formContext == FormContextType.Header)
+            {
+                TryCloseHeaderFlyout(driver);
+            }
 
             return true;
         }


### PR DESCRIPTION
### Type of change

- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (updates to documentation, formatting, etc.)

### Description
Using DateTime in form, returning error 
"    OpenQA.Selenium.NoSuchElementException: no such element: Unable to locate element: {"method":"xpath","selector":"//button[contains(@id,'headerFieldsExpandButton')]"}"

### Issues addressed
This fixes the SetValue for DateTime. UCI.

### All submissions:

- [X ] My code follows the code style of this project.
- [ ] Do existing samples that are effected by this change still run?
- [ ] I have added samples for new functionality. 
- [ ] I raise detailed error messages when possible.
- [ ] My code does not rely on labels that have the option to be hidden.

### Which browsers was this tested on?
<!--- Should be tested on Chrome, Firefox, and IE. -->
- [X ] Chrome
- [ ] Firefox
- [ ] IE
- [ ] Edge
