### PR TITLE
Fix issue that SetValue For Lookup Taking too much time

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -1194,7 +1194,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             var xpathToItems = By.XPath(AppElements.Xpath[AppReference.Entity.LookupFieldResultListItem].Replace("[NAME]", name));
 
             //wait for complete the search
-            container.WaitUntil(d => d.FindVisible(By.XPath(".//li/div/label/span"))?.Text?.Contains(control.Value, StringComparison.OrdinalIgnoreCase) == true);
+            container.WaitUntil(d => d.FindVisible(xpathToItems)?.Text?.Contains(control.Value, StringComparison.OrdinalIgnoreCase) == true);
 
             ICollection<IWebElement> result = container.WaitUntil(
                 d => d.FindElements(xpathToItems),
@@ -2386,7 +2386,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             if (found)
                 SetInputValue(driver, input, value);
 
-            TrySetValue(fieldContainer, control);
+            TrySetValue(driver, control);
         }
 
         /// <summary>


### PR DESCRIPTION
### Type of change

- [+] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (updates to documentation, formatting, etc.)

### Description
SetValue For Lookup Taking too much time due to incorrect container used for waiting for data load in lookup.
Use Driver as a container for Lookup popup instead of input with lookup text and fix XPath for lookup search results.

### Issues addressed
#997

### All submissions:

- [+] My code follows the code style of this project.
- [+] Do existing samples that are affected by this change still run?
- [ ] I have added samples for new functionality. 
- [ ] I raise detailed error messages when possible.
- [+] My code does not rely on labels that have the option to be hidden.

### Which browsers was this tested on?
<!--- Should be tested on Chrome, Firefox, and IE. -->
- [+] Chrome
- [ ] Firefox
- [ ] IE
- [ ] Edge
