### PR TITLE
fix: incorrect IDs returned for subgrid items

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/AppElementReference.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/AppElementReference.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
 using System.Collections.Generic;
@@ -331,7 +331,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             { "Nav_AreaMoreMenu"       , "//ul[@role=\"menubar\"]"},
             { "Nav_SubAreaContainer"       , "//*[@data-id=\"navbar-container\"]/div/ul"},
             { "Nav_WebAppMenuButton"       , "//*[@id=\"TabArrowDivider\"]/a"},
-            { "Nav_UCIAppMenuButton"       , "//button[@data-id=\"navbar-switch-app\"]"},
+            { "Nav_UCIAppMenuButton"       , "//a[@data-id=\"appBreadCrumb\"]"},
             { "Nav_SiteMapLauncherButton", "//button[@data-lp-id=\"sitemap-launcher\"]" },
             { "Nav_SiteMapLauncherCloseButton", "//button[@data-id='navbutton']" },
             { "Nav_SiteMapAreaMoreButton", "//button[@data-lp-id=\"sitemap-areaBar-more-btn\"]" },
@@ -470,7 +470,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             { "Entity_FormMessageBar", "//*[@id=\"notificationMessageAndButtons\"]/div/div/span" },
             { "Entity_FormMessageBarTypeIcon", ".//span[contains(@data-id,'formReadOnlyIcon')]" },
             { "Entity_FormNotifcationBar", "//div[contains(@data-id, 'notificationWrapper')]" },
-            { "Entity_FormNotifcationTypeIcon", ".//span[contains(@id,'notification_icon_')]" },            
+            { "Entity_FormNotifcationTypeIcon", ".//span[contains(@id,'notification_icon_')]" },
             { "Entity_FormNotifcationExpandButton", ".//span[@id='notificationExpandIcon']" },
             { "Entity_FormNotifcationFlyoutRoot", "//div[@id='__flyoutRootNode']" },
             { "Entity_FormNotifcationList", ".//ul[@data-id='notificationList']" },

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -3635,14 +3635,17 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                     var rows = subGrid.FindElements(By.XPath(AppElements.Xpath[AppReference.Entity.SubGridRowsHighDensity]));
 
                     //Process each row
+                    var jsExecutor = (IJavaScriptExecutor)driver;
                     foreach (IWebElement row in rows)
                     {
                         //Get the entityId and entity Type
                         if (row.GetAttribute("data-lp-id") != null)
                         {
                             var rowAttributes = row.GetAttribute("data-lp-id").Split('|');
-                            item.Id = Guid.Parse(rowAttributes[3]);
                             item.EntityName = rowAttributes[4];
+                            //The row record IDs are not in the DOM. Must be retrieved via JavaScript
+                            var getId = $"return Xrm.Page.getControl(\"{subgridName}\").getGrid().getRows().get({rows.IndexOf(row)}).getData().entity.getId()";
+                            item.Id = new Guid((string)jsExecutor.ExecuteScript(getId));
                         }
 
                         var cells = row.FindElements(By.XPath(AppElements.Xpath[AppReference.Entity.SubGridCells]));

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
 using OpenQA.Selenium;
@@ -3635,7 +3635,6 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                     var rows = subGrid.FindElements(By.XPath(AppElements.Xpath[AppReference.Entity.SubGridRowsHighDensity]));
 
                     //Process each row
-                    var jsExecutor = (IJavaScriptExecutor)driver;
                     foreach (IWebElement row in rows)
                     {
                         //Get the entityId and entity Type
@@ -3645,7 +3644,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                             item.EntityName = rowAttributes[4];
                             //The row record IDs are not in the DOM. Must be retrieved via JavaScript
                             var getId = $"return Xrm.Page.getControl(\"{subgridName}\").getGrid().getRows().get({rows.IndexOf(row)}).getData().entity.getId()";
-                            item.Id = new Guid((string)jsExecutor.ExecuteScript(getId));
+                            item.Id = new Guid((string)driver.ExecuteScript(getId));
                         }
 
                         var cells = row.FindElements(By.XPath(AppElements.Xpath[AppReference.Entity.SubGridCells]));

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -382,7 +382,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                         appMenu =>
                         {
                             appMenu.Click(true);
-                            found = OpenAppFromMenu(driver, appName);
+                            found = TryToClickInAppTile(appName, driver) || OpenAppFromMenu(driver, appName);
                         });
             return found;
         }
@@ -1443,7 +1443,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                     viewPicker.Click(true);
 
                     // Locate the ViewSelector flyout
-                    var viewPickerFlyout = driver.WaitUntilAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.SubGridViewPickerFlyout]), new TimeSpan(0,0,2));
+                    var viewPickerFlyout = driver.WaitUntilAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.SubGridViewPickerFlyout]), new TimeSpan(0, 0, 2));
 
                     var viewItems = viewPickerFlyout.FindElements(By.TagName("li"));
 
@@ -2448,7 +2448,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             string value = control.Value;
             if (value == null)
                 control.Value = string.Empty;
-                // throw new InvalidOperationException($"No value has been provided for the LookupItem {control.Name}. Please provide a value or an empty string and try again.");
+            // throw new InvalidOperationException($"No value has been provided for the LookupItem {control.Name}. Please provide a value or an empty string and try again.");
 
             if (control.Value == string.Empty)
                 SetLookupByIndex(container, control);
@@ -2808,12 +2808,12 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 {
                     dateField.Click(true);
                     if (date != null)
-                    {                        
+                    {
                         dateField = dateField.FindElement(By.TagName("input"));
 
                         // Only send Keys.Escape to avoid element not interactable exceptions with calendar flyout on forms.
                         // This can cause the Header or BPF flyouts to close unexpectedly
-                        if (formContextType == FormContextType.Entity || formContextType == FormContextType.QuickCreate )
+                        if (formContextType == FormContextType.Entity || formContextType == FormContextType.QuickCreate)
                         {
                             dateField.SendKeys(Keys.Escape);
                         }
@@ -2851,7 +2851,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 //IWebDriver formContext;
                 // Initialize the quick create form context
                 // If this is not done -- element input will go to the main form due to new flyout design
-                formContext = container.WaitUntilAvailable(By.XPath(AppElements.Xpath[AppReference.QuickCreate.QuickCreateFormContext]), new TimeSpan(0,0, 1));
+                formContext = container.WaitUntilAvailable(By.XPath(AppElements.Xpath[AppReference.QuickCreate.QuickCreateFormContext]), new TimeSpan(0, 0, 1));
             }
             else if (formContextType == FormContextType.Entity)
             {
@@ -2916,7 +2916,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                     RemoveMultiOptions(option, formContextType);
                 }
 
-                
+
                 AddMultiOptions(option, formContextType);
 
                 return true;
@@ -2979,7 +2979,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                     // Hover the field to expose the Select Record buttons
                     fieldContainer.Hover(driver, true);
                 }
-                    
+
 
                 xpath = String.Format(AppElements.Xpath[AppReference.MultiSelect.SelectedRecordButton].Replace("[NAME]", option.Name));
                 var listItemObjects = fieldContainer.FindElements(By.XPath(xpath));
@@ -3069,17 +3069,17 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                         input.SendKeys(optionValue);
                         ThinkTime(2000);
                         var searchFlyout = fieldContainer.WaitUntilAvailable(By.XPath(AppElements.Xpath[AppReference.MultiSelect.Flyout].Replace("[NAME]", option.Name)));
-                        ThinkTime(2000);  
+                        ThinkTime(2000);
                         var searchResultList = searchFlyout.FindElements(By.TagName("li"));
 
-                        
+
                         // Is the item in search results?
                         if (searchResultList.Any(x => x.GetAttribute("aria-label").Contains(optionValue, StringComparison.OrdinalIgnoreCase)))
                         {
                             searchResultList.FirstOrDefault(x => x.GetAttribute("aria-label").Contains(optionValue, StringComparison.OrdinalIgnoreCase)).Click(true);
                             driver.WaitForTransaction();
                         }
-                    }    
+                    }
                 }
 
                 // Click on the div containing textbox so that the floyout collapses or else the flyout
@@ -3482,7 +3482,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             return this.Execute(GetOptions($"Get Header Title"), driver =>
             {
                 // Wait for form selector visible
-                var headerTitle = driver.WaitUntilVisible(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderTitle]), new TimeSpan(0,0,5));
+                var headerTitle = driver.WaitUntilVisible(By.XPath(AppElements.Xpath[AppReference.Entity.HeaderTitle]), new TimeSpan(0, 0, 5));
 
                 var headerTitleName = headerTitle?.Text;
 
@@ -3529,7 +3529,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                         {
                             var recordLabels = recordRow.FindElements(By.TagName("label"));
 
-                            foreach(IWebElement label in recordLabels)
+                            foreach (IWebElement label in recordLabels)
                             {
                                 if (label.GetAttribute("id") != null)
                                 {
@@ -3565,7 +3565,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                     }
                     else
                         throw new NotFoundException($"Unable to locate record list for subgrid {subgridName}");
-                  
+
                 }
                 // Attempt to locate the editable grid list
                 else if (subGrid.TryFindElement(By.XPath(AppElements.Xpath[AppReference.Entity.EditableSubGridList].Replace("[NAME]", subgridName)), out subGridRecordList))
@@ -3706,10 +3706,10 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 
                     return true;
                 }
-                else if(!foundGrid)
+                else if (!foundGrid)
                 {
                     // Read Only Grid Not Found
-                   var foundEditableGrid = subGrid.TryFindElement(By.XPath(AppElements.Xpath[AppReference.Entity.EditableSubGridList].Replace("[NAME]", subgridName)), out subGridRecordList);
+                    var foundEditableGrid = subGrid.TryFindElement(By.XPath(AppElements.Xpath[AppReference.Entity.EditableSubGridList].Replace("[NAME]", subgridName)), out subGridRecordList);
 
                     if (foundEditableGrid)
                     {
@@ -4355,7 +4355,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                     {
                         icon = driver.FindElement(By.XPath(AppElements.Xpath[AppReference.Entity.FormMessageBarTypeIcon]));
                     }
-                    catch(NoSuchElementException)
+                    catch (NoSuchElementException)
                     {
                         // Swallow the exception
                     }
@@ -4708,7 +4708,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             {
                 var inputbox = driver.WaitUntilAvailable(By.XPath(Elements.Xpath[fieldName]));
                 if (expectedTagName.Equals(inputbox.TagName, StringComparison.InvariantCultureIgnoreCase))
-                {                    
+                {
                     if (!inputbox.TagName.Contains("iframe", StringComparison.InvariantCultureIgnoreCase))
                     {
                         inputbox.Click(true);
@@ -4747,7 +4747,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 
                 // Initialize the Business Process Flow context
                 var formContext = driver.WaitUntilAvailable(By.XPath(AppElements.Xpath[AppReference.BusinessProcessFlow.BusinessProcessFlowFormContext]));
-                var fieldElement = formContext.WaitUntilAvailable(By.XPath(AppElements.Xpath[AppReference.BusinessProcessFlow.FieldSectionItemContainer].Replace("[NAME]", field)));                
+                var fieldElement = formContext.WaitUntilAvailable(By.XPath(AppElements.Xpath[AppReference.BusinessProcessFlow.FieldSectionItemContainer].Replace("[NAME]", field)));
                 Field returnField = new Field(fieldElement);
                 returnField.Name = field;
 

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
 using OpenQA.Selenium;


### PR DESCRIPTION
### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Description

Fixed `GetSubGridItems` to return the correct record IDs. Unfortunately, these are not stored in the DOM (the GUID previously being assigned to the `Id` was actually the Saved Query ID) so we're forced to use JavaScript.

### Issues addressed

Wasn't able to find any active issues mentioning this problem. However, anyone attempting to use the `Id` of the items returned by `GetSubGridItems` would face issues.

### All submissions:

- [x] My code follows the code style of this project.
- [x] Do existing samples that are effected by this change still run?
- [x] I have added samples for new functionality. 
- [x] I raise detailed error messages when possible.
- [x] My code does not rely on labels that have the option to be hidden.

### Which browsers was this tested on?
<!--- Should be tested on Chrome, Firefox, and IE. -->
- [x] Chrome
- [x] Firefox
- [x] IE
- [x] Edge
