### PR TITLE
fix: unable to clear quick creates on lookups

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -4066,13 +4066,6 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 var count = existingValues.Count;
                 fieldContainer.WaitUntil(x => x.FindElements(xpathDeleteExistingValues).Count > count);
             }
-            else if (!isHeader && !success)
-            {
-                var xpathToHoveExistingValue = By.XPath(AppElements.Xpath[AppReference.Entity.LookupFieldHoverExistingValue].Replace("[NAME]", controlName));
-                var found = fieldContainer.TryFindElement(xpathToHoveExistingValue, out var existingList);
-                if (found)
-                    existingList.Click(true);
-            }
 
             fieldContainer.WaitUntilAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.TextFieldLookupSearchButton].Replace("[NAME]", controlName)));
 


### PR DESCRIPTION
### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Description

Removes seemingly unneeded code from the `TryRemoveLookupValue` method. Have tested before and after removing this code for setting quick create lookups, main form lookups, and activity parties and it doesn't seem to serve any purpose.

### Issues addressed

Clearing a quick create lookup value would result in a warning dialog overlaying the screen as it was attempting to click off the quick create.

Refer to this test failure and attachment: https://dev.azure.com/capgeminiuk/GitHub%20Support/_build/results?buildId=4744&view=ms.vss-test-web.build-test-results-tab&runId=1002934&resultId=100067&paneView=debug

### All submissions:

- [x] My code follows the code style of this project.
- [x] Do existing samples that are effected by this change still run?
- [x] I have added samples for new functionality. 
- [x] I raise detailed error messages when possible.
- [x] My code does not rely on labels that have the option to be hidden.

### Which browsers was this tested on?
<!--- Should be tested on Chrome, Firefox, and IE. -->
- [x] Chrome
- [ ] Firefox
- [ ] IE
- [ ] Edge
