### PR TITLE
fix: unable to set boolean on BPF

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/AppElementReference.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/AppElementReference.cs
@@ -239,6 +239,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             public static string FieldSectionItemContainer = "BPF_FieldSectionItemContainer";
             public static string TextFieldLabel = "BPF_TextFieldLabel";
             public static string BooleanFieldContainer = "BPF_BooleanFieldContainer";
+            public static string BooleanFieldSelectedOption = "BPF_BooleanFieldSelectedOption";
             public static string DateTimeFieldContainer = "BPF_DateTimeFieldContainer";
             public static string FieldControlDateTimeInputUCI = "BPF_FieldControlDateTimeInputUCI";
             public static string PinStageButton = "BPF_PinStageButton";
@@ -532,7 +533,8 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             { "BPF_FormContext"     , "//div[contains(@id, \'ProcessStageControl-processHeaderStageFlyoutInnerContainer\')]" },
             { "BPF_TextFieldContainer", ".//div[contains(@data-lp-id, \'header_process_[NAME]\')]" },
             { "BPF_TextFieldLabel", "//label[contains(@id, \'header_process_[NAME]-field-label\')]" },
-            { "BPF_BooleanFieldContainer", ".//input[contains(@data-id, \'header_process_[NAME].fieldControl-checkbox-toggle\')]" },
+            { "BPF_BooleanFieldContainer", ".//div[contains(@data-id, \'header_process_[NAME].fieldControl-checkbox-container\')]" },
+            { "BPF_BooleanFieldSelectedOption", ".//div[contains(@data-id, \'header_process_[NAME].fieldControl-checkbox-container\') and contains(@aria-checked, \'true\')]" },
             { "BPF_DateTimeFieldContainer", ".//input[contains(@data-id, \'[NAME].fieldControl-date-time-input\')]" },
             { "BPF_FieldControlDateTimeInputUCI",".//input[contains(@data-id,'[FIELD].fieldControl-date-time-input')]" },
             { "BPF_PinStageButton","//button[contains(@id,'stageDockModeButton')]"},

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/Elements/BusinessProcessFlow.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/Elements/BusinessProcessFlow.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         /// <summary>
         /// Retrieves the value of a Lookup field
         /// </summary>
-        /// <param name="field">LookupItem with the schema name of the field to retrieve
+        /// <param name="field">LookupItem with the schema name of the field to retrieve</param>
         public string GetValue(LookupItem field)
         {
             return _client.GetValue(field);
@@ -42,8 +42,17 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         /// <summary>
         /// Retrieves the value of a OptionSet field
         /// </summary>
-        /// <param name="field">OptionSet with the schema name of the field to retrieve
+        /// <param name="field">OptionSet with the schema name of the field to retrieve</param
         public string GetValue(OptionSet field)
+        {
+            return _client.GetValue(field);
+        }
+
+        /// <summary>
+        /// Retrieves the value of a BooleanItem field.
+        /// </summary>
+        /// <param name="field">BooleanItem with the schema name of the field to retrieve.</param>
+        public bool GetValue(BooleanItem field)
         {
             return _client.GetValue(field);
         }

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -4854,27 +4854,12 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             return this.Execute(GetOptions($"Set BPF Value: {option.Name}"), driver =>
             {
                 var fieldContainer = driver.WaitUntilAvailable(By.XPath(AppElements.Xpath[AppReference.BusinessProcessFlow.BooleanFieldContainer].Replace("[NAME]", option.Name)));
-                if (!option.Value)
+                var selectedOption = fieldContainer.FindElement(By.XPath(AppElements.Xpath[AppReference.BusinessProcessFlow.BooleanFieldSelectedOption].Replace("[NAME]", option.Name)));
+
+                var existingValue = selectedOption.GetAttribute<string>("Title") == "Yes";
+                if (option.Value != existingValue)
                 {
-                    if (!fieldContainer.Selected)
-                    {
-                        fieldContainer.Click(true);
-                    }
-                    else
-                    {
-                        fieldContainer.Click(true);
-                    }
-                }
-                else
-                {
-                    if (fieldContainer.Selected)
-                    {
-                        fieldContainer.Click(true);
-                    }
-                    else
-                    {
-                        fieldContainer.Click(true);
-                    }
+                    fieldContainer.Click();
                 }
 
                 return true;


### PR DESCRIPTION
### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Description
- Corrected `AppElements` XPath for BPF boolean field
- Corrected and refactored `BPFSetValue(BooleanItem option)` method
- Added a `GetValue` overload for `BooleanItem`

### Issues addressed
I believe this fixes #971 and fixes #869. Also refer to failing screenshot here: https://dev.azure.com/capgeminiuk/GitHub%20Support/_build/results?buildId=4744&view=ms.vss-test-web.build-test-results-tab&runId=1002934&resultId=100097&paneView=debug.

### All submissions:

- [x] My code follows the code style of this project.
- [x] Do existing samples that are effected by this change still run?
- [x] I have added samples for new functionality. 
- [x] I raise detailed error messages when possible.
- [x] My code does not rely on labels that have the option to be hidden.

### Which browsers was this tested on?
- [x] Chrome
- [ ] Firefox
- [ ] IE
- [ ] Edge
