### PR TITLE
fix: signout broken

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/AppElementReference.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/AppElementReference.cs
@@ -26,6 +26,8 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             public static string AppMenuContainer = "Nav_AppMenuContainer";
             public static string SettingsLauncherBar = "Nav_SettingsLauncherBar";
             public static string SettingsLauncher = "Nav_SettingsLauncher";
+            public static string AccountManagerButton = "Nav_AccountManagerButton";
+            public static string AccountManagerSignOutButton = "Nav_AccountManagerSignOutButton";
             public static string GuidedHelp = "Nav_GuidedHelp";
             public static string AdminPortal = "Nav_AdminPortal";
             public static string AdminPortalButton = "Nav_AdminPortalButton";
@@ -339,6 +341,8 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             { "Nav_AppMenuContainer"       , "//*[@id=\"taskpane-scroll-container\"]"},
             { "Nav_SettingsLauncherBar"       , "//button[@data-id='[NAME]Launcher']"},
             { "Nav_SettingsLauncher"       , "//div[@id='[NAME]Launcher']"},
+            { "Nav_AccountManagerButton", "//*[@id=\"mectrl_main_trigger\"]" },
+            { "Nav_AccountManagerSignOutButton", "//*[@id=\"mectrl_body_signOut\"]" },
             { "Nav_GuidedHelp"       , "//*[@id=\"helpLauncher\"]/button"},
             //{ "Nav_AdminPortal"       , "//*[@id=(\"id-5\")]"},
             { "Nav_AdminPortal"       , "//*[contains(@data-id,'officewaffle')]"},

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/Elements/Navigation.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/Elements/Navigation.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         {
             _client.OpenGroupSubArea(group, subarea);
         }
-        
+
         /// <summary>
         /// Opens a area in the unified client
         /// </summary>
@@ -117,7 +117,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         /// </summary>
         public void SignOut()
         {
-            _client.OpenSettingsOption("userInformation", "UserInformationMenu.SignOut");
+            _client.SignOut();
         }
 
         /// <summary>
@@ -153,12 +153,12 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         {
             _client.OpenAndClickPopoutMenu(menuName, menuItemName);
         }
-		
+
         /// <summary>
         /// Clicks the quick create button (+ icon)
         /// </summary>
         /// <param name="entityName"></param>
-		public void QuickCreate(string entityName)
+        public void QuickCreate(string entityName)
         {
             _client.QuickCreate(entityName);
         }

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -340,6 +340,18 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 
         #region Navigation
 
+        internal BrowserCommandResult<bool> SignOut()
+        {
+            return Execute(GetOptions("Sign out"), driver =>
+            {
+                driver.WaitUntilClickable(By.XPath(AppElements.Xpath[AppReference.Navigation.AccountManagerButton])).Click();
+                driver.WaitUntilClickable(By.XPath(AppElements.Xpath[AppReference.Navigation.AccountManagerSignOutButton])).Click();
+
+                return driver.WaitForPageToLoad();
+            });
+        }
+
+
         internal BrowserCommandResult<bool> OpenApp(string appName, int thinkTime = Constants.DefaultThinkTime)
         {
             ThinkTime(thinkTime);


### PR DESCRIPTION
### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Description

- Added new XPath selectors into `AppElements` for the account manager and sign out button.
- Updated the `Navigation.SignOut` method

### Issues addressed
Fixes #1011. Also refer to this failing test and screenshot: https://capgeminiuk.visualstudio.com/GitHub%20Support/_build/results?buildId=4744&view=ms.vss-test-web.build-test-results-tab&runId=1002934&paneView=debug&resultId=100027

### All submissions:

- [x] My code follows the code style of this project.
- [x] Do existing samples that are effected by this change still run?
- [x] I have added samples for new functionality. 
- [x] I raise detailed error messages when possible.
- [x] My code does not rely on labels that have the option to be hidden.

### Which browsers was this tested on?
- [x] Chrome
- [ ] Firefox
- [ ] IE
- [ ] Edge
