### PR TITLE
fix: SelectForm doesn't wait for form to finish loading

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -4163,11 +4163,8 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 driver.ClickWhenAvailable(By.Id(form.GetAttribute("id")));
 
                 driver.WaitForPageToLoad();
+                driver.WaitForTransaction();
 
-                driver.WaitUntilClickable(By.XPath(Elements.Xpath[Reference.Entity.Form]),
-                    TimeSpan.FromSeconds(30),
-                    "CRM Record is Unavailable or not finished loading. Timeout Exceeded"
-                );
                 return true;
             });
         }


### PR DESCRIPTION
### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Description
Uses `driver.WaitForTransaction()` after switching form rather than waiting until the form is clickable.

### Issues addressed
Refer to this failing test and screenshot: https://capgeminiuk.visualstudio.com/GitHub%20Support/_build/results?buildId=4744&view=ms.vss-test-web.build-test-results-tab&runId=1002934&paneView=attachments&resultId=100013

After introducing `driver.WaitForTransaction()` to the end of `SelectForm`, the form notifications are populated.

### All submissions:

- [x] My code follows the code style of this project.
- [x] Do existing samples that are effected by this change still run?
- [x] I have added samples for new functionality. 
- [x] I raise detailed error messages when possible.
- [x] My code does not rely on labels that have the option to be hidden.

### Which browsers was this tested on?
<!--- Should be tested on Chrome, Firefox, and IE. -->
- [x] Chrome
- [ ] Firefox
- [ ] IE
- [ ] Edge
