### PR TITLE
fix: error clearing datetime time component

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/Controls/DateTimeControl.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/Controls/DateTimeControl.cs
@@ -19,16 +19,18 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 
         public string DateFormat { get; set; }
         public string TimeFormat { get; set; }
-        
+
         private string _dateAsString;
-        public string DateAsString { 
-            get =>  _dateAsString ?? (_dateAsString = string.IsNullOrWhiteSpace(DateFormat) ? Value?.ToShortDateString() : Value?.ToString(DateFormat));
+        public string DateAsString
+        {
+            get => _dateAsString ?? (_dateAsString = string.IsNullOrWhiteSpace(DateFormat) ? Value?.ToShortDateString() : Value?.ToString(DateFormat));
             set => _dateAsString = value;
         }
 
         private string _timeAsString;
-        public string TimeAsString { 
-            get =>  _timeAsString ?? (_timeAsString = string.IsNullOrWhiteSpace(TimeFormat) ? Value?.ToShortTimeString().ToUpper() : Value?.ToString(TimeFormat)).ToUpper();
+        public string TimeAsString
+        {
+            get => _timeAsString ?? (_timeAsString = string.IsNullOrWhiteSpace(TimeFormat) ? Value?.ToShortTimeString()?.ToUpper() : Value?.ToString(TimeFormat))?.ToUpper();
             set => _timeAsString = value;
         }
     }


### PR DESCRIPTION
### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Description
Added missing null-conditional member access operator to avoid calling `ToUpper()` on null.

### Issues addressed
Clearing a datetime field would throw a null reference exception when clearing the time component. See failing test: https://dev.azure.com/capgeminiuk/GitHub%20Support/_build/results?buildId=4744&view=ms.vss-test-web.build-test-results-tab&runId=1002934&resultId=100123&paneView=debug

### All submissions:

- [x] My code follows the code style of this project.
- [x] Do existing samples that are effected by this change still run?
- [x] I have added samples for new functionality. 
- [x] I raise detailed error messages when possible.
- [x] My code does not rely on labels that have the option to be hidden.

### Which browsers was this tested on?
<!--- Should be tested on Chrome, Firefox, and IE. -->
- [x] Chrome
- [ ] Firefox
- [ ] IE
- [ ] Edge
