### PR TITLE
fix: get and set multi-select option set values

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/AppElementReference.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/AppElementReference.cs
@@ -205,9 +205,11 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             public static string InputSearch = "MultiSelect_InputSearch";
             public static string SelectedRecord = "MultiSelect_SelectedRecord";
             public static string SelectedRecordButton = "MultiSelect_SelectedRecord_Button";
+            public static string SelectedOptionDeleteButton = "MultiSelect_SelectedRecord_DeleteButton";
             public static string SelectedRecordLabel = "MultiSelect_SelectedRecord_Label";
-            public static string Flyout = "MultiSelect_Flyout";
-            public static string FlyoutList = "MultiSelect_FlyoutList";
+            public static string FlyoutCaret = "MultiSelect_FlyoutCaret";
+            public static string FlyoutOption = "MultiSelect_FlyoutOption";
+            public static string FlyoutOptionCheckbox = "MultiSelect_FlyoutOptionCheckbox";
             public static string ExpandCollapseButton = "MultiSelect_ExpandCollapseButton";
         }
 
@@ -514,13 +516,14 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 
             //MultiSelect
             { "MultiSelect_DivContainer",     ".//div[contains(@data-id,\"[NAME]-FieldSectionItemContainer\")]" },
-            { "MultiSelect_InputSearch",     ".//div[contains(@data-id,\"[NAME].fieldControl-LookupResultsDropdown_[NAME]_InputSearch\")]" },
-            { "MultiSelect_SelectedRecord",  ".//ul[contains(@data-id,\"[NAME].fieldControl-LookupResultsDropdown_[NAME]_SelectedRecordList\")]//li" },
-            { "MultiSelect_SelectedRecord_Button",  ".//ul[contains(@data-id,\"[NAME].fieldControl-LookupResultsDropdown_[NAME]\") and contains(@data-id, 'SelectedRecordList')]//li" },
-            { "MultiSelect_SelectedRecord_Label",  ".//ul[contains(@data-id,\"[NAME].fieldControl-LookupResultsDropdown_[NAME]_SelectedRecordList\")]/descendant::label" },
-            { "MultiSelect_Flyout",      "//div[contains(@id,\"[NAME].fieldControl|__flyoutRootNode_SimpleLookupControlFlyout\")]//ul" },
-            { "MultiSelect_FlyoutList",      "//div[contains(@id,\"[NAME].fieldControl|__flyoutRootNode_SimpleLookupControlFlyout\")]//li[descendant::label[contains(text(), \"{0}\")]]" },
-            { "MultiSelect_ExpandCollapseButton", ".//button[contains(@data-id,\"[NAME].fieldControl-LookupResultsDropdown_[NAME]_expandCollapse\")]/descendant::label[not(text()=\"+0\")]" },
+            { "MultiSelect_InputSearch",     ".//input[contains(@class,\"msos-input\")]" },
+            { "MultiSelect_SelectedRecord",  ".//li[contains(@class, \"msos-selected-display-item\")]" },
+            { "MultiSelect_SelectedRecord_DeleteButton", ".//button[contains(@class, \"msos-quick-delete\")]" },
+            { "MultiSelect_SelectedRecord_Label",  ".//span[contains(@class, \"msos-selected-display-item-text\")]" },
+            { "MultiSelect_FlyoutOption",      "//li[label[contains(@title, \"[NAME]\")] and contains(@class,\"msos-option\")]" },
+            { "MultiSelect_FlyoutOptionCheckbox", "//input[contains(@class, \"msos-checkbox\")]" },
+            { "MultiSelect_FlyoutCaret", "//button[contains(@class, \"msos-caret-button\")]" },
+            { "MultiSelect_ExpandCollapseButton", ".//button[contains(@class,\"msos-selecteditems-toggle\")]" },
 
             //Dashboard
             { "Dashboard_Selector"       , "//span[contains(@id, 'Dashboard_Selector')]"},

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/Elements/Entity.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/Elements/Entity.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         {
             _client.ClearValue(control, FormContextType.Entity);
         }
-        
+
 
         /// <summary>
         /// Clears a value from the DateTimeControl provided
@@ -179,7 +179,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         {
             return _client.GetHeaderValue(control);
         }
-        
+
         /// <summary>
         /// Gets the value of a Boolean Item from the header
         /// </summary>
@@ -208,7 +208,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         {
             return _client.GetHeaderValue(control);
         }
-        
+
         /// <summary>
         /// Gets the value of a DateTime Control from the header
         /// </summary>
@@ -218,7 +218,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         {
             return _client.GetHeaderValue(control);
         }
-        
+
         /// <summary>
         /// Get the object id of the current entity
         /// </summary>
@@ -242,7 +242,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         {
             return _client.GetFormName();
         }
-        
+
         /// <summary>
         /// Get the Header Title of the current entity
         /// </summary>
@@ -281,7 +281,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             return _client.GetValue(control);
         }
 
-        
+
         /// <summary>
         /// Gets the value of a Lookup.
         /// </summary>
@@ -333,9 +333,9 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         /// Gets the value of a MultiValueOptionSet.
         /// </summary>
         /// <param name="option">The option you want to set.</param>
-        public void GetValue(MultiValueOptionSet option)
+        public MultiValueOptionSet GetValue(MultiValueOptionSet option)
         {
-            _client.GetValue(option);
+            return _client.GetValue(option);
         }
 
         /// <summary>
@@ -558,7 +558,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         {
             _client.SetValue(option, FormContextType.Entity, removeExistingValues);
         }
-        
+
         /// <summary>
         /// Click Process>Switch Process
         /// </summary>
@@ -597,5 +597,5 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         {
             _client.RemoveValues(controls);
         }
-    }   
+    }
 }


### PR DESCRIPTION
### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Description
- Updates old XPath selectors in `AppElements`
- Fixes `void` return type in `Entity`
- Corrects logic in 
  - `RemoveMultiOptions(MultiValueOptionSet option)`
  - `AddMultiOptions(MultiValueOptionSet option)`
  - `GetValue(MultiValueOptionSet option)`

### Issues addressed
Fixes #598. Setting or retrieving multi-select option set values was not working.

### All submissions:

- [x] My code follows the code style of this project.
- [x] Do existing samples that are effected by this change still run?
- [x] I have added samples for new functionality. 
- [x] I raise detailed error messages when possible.
- [x] My code does not rely on labels that have the option to be hidden.

### Which browsers was this tested on?
<!--- Should be tested on Chrome, Firefox, and IE. -->
- [x] Chrome
- [ ] Firefox
- [ ] IE
- [ ] Edge
