### PR TITLE
fix: error setting header fields on form load

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -4216,9 +4216,9 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 
         internal void TryExpandHeaderFlyout(IWebDriver driver)
         {
-            bool hasHeader = driver.HasElement(By.XPath(AppElements.Xpath[AppReference.Entity.Header.Container]));
-            if (!hasHeader)
-                throw new NotFoundException("Unable to find header on the form");
+            driver.WaitUntilAvailable(
+                By.XPath(AppElements.Xpath[AppReference.Entity.Header.Container]),
+                "Unable to find header on the form");
 
             var xPath = By.XPath(AppElements.Xpath[AppReference.Entity.Header.FlyoutButton]);
             var headerFlyoutButton = driver.FindElement(xPath);


### PR DESCRIPTION
### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Description
Replacing `driver.HasElement` with `driver.WaitUntilAvailable` to allow for loading.

### Issues addressed
Setting a header value immediately after opening a form will usually fail to find the header. See this test run and screenshot: https://dev.azure.com/capgeminiuk/GitHub%20Support/_build/results?buildId=4744&view=ms.vss-test-web.build-test-results-tab&runId=1002934&resultId=100106&paneView=debug

### All submissions:

- [x] My code follows the code style of this project.
- [x] Do existing samples that are effected by this change still run?
- [x] I have added samples for new functionality. 
- [x] I raise detailed error messages when possible.
- [x] My code does not rely on labels that have the option to be hidden.

### Which browsers was this tested on?
<!--- Should be tested on Chrome, Firefox, and IE. -->
- [x] Chrome
- [ ] Firefox
- [ ] IE
- [ ] Edge
