### PR TITLE
fix: GetValue missing for quick create datetimes

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/Elements/QuickCreate.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/Elements/QuickCreate.cs
@@ -73,6 +73,16 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         }
 
         /// <summary>
+        /// Gets the value of a DateTime field in the quick create form.
+        /// </summary>
+        /// <param name="control">The control.</param>
+        /// <returns>The value.</returns>
+        public DateTime? GetValue(DateTimeControl control)
+        {
+            return _client.GetValue(control);
+        }
+
+        /// <summary>
         /// Gets the value of a LookupItem field in the quick create form
         /// </summary>
         /// <param name="control">LookupItem of the field to set</param>


### PR DESCRIPTION
### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Description

Added a `GetValue` overload to `QuickCreate` to return `DateTime?` values.

### Issues addressed

This overload is available on `Entity` but not on `QuickCreate`.

### All submissions:

- [x] My code follows the code style of this project.
- [x] Do existing samples that are effected by this change still run?
- [x] I have added samples for new functionality. 
- [x] I raise detailed error messages when possible.
- [x] My code does not rely on labels that have the option to be hidden.

### Which browsers was this tested on?
<!--- Should be tested on Chrome, Firefox, and IE. -->
- [x] Chrome
- [ ] Firefox
- [ ] IE
- [ ] Edge
