### PR TITLE
fix: selecting a lookup entity broken

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/AppElementReference.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/AppElementReference.cs
@@ -592,7 +592,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             { "QuickCreate_CancelButton", "//button[contains(@id,'quickCreateCancelBtn')]"},
 
             //Lookup
-            { "Lookup_RelatedEntityLabel", "//li[contains(@title,'[NAME]') and contains(@data-id,'LookupResultsDropdown')]" },
+            { "Lookup_RelatedEntityLabel", "//li[contains(@aria-label,'[NAME]') and contains(@data-id,'LookupResultsDropdown')]" },
             { "Lookup_ChangeViewButton", "//button[contains(@data-id,'changeViewBtn')]"},
             { "Lookup_ViewRows", "//li[contains(@data-id,'viewLineContainer')]"},
             { "Lookup_ResultRows", "//li[contains(@data-id,'LookupResultsDropdown') and contains(@data-id,'resultsContainer')]"},


### PR DESCRIPTION
### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Description
Fixes the XPath for a lookup entity label (e.g. 'Accounts' or 'Contacts' in a customer field).

### Issues addressed
`XrmApp.Lookup.SelectRelatedEntity(string entityLabel)` would always result in an exception. Refer to this test run and screenshot: https://dev.azure.com/capgeminiuk/GitHub%20Support/_build/results?buildId=4744&view=ms.vss-test-web.build-test-results-tab&runId=1002934&resultId=100114&paneView=debug.

### All submissions:

- [x] My code follows the code style of this project.
- [x] Do existing samples that are effected by this change still run?
- [x] I have added samples for new functionality. 
- [x] I raise detailed error messages when possible.
- [x] My code does not rely on labels that have the option to be hidden.

### Which browsers was this tested on?
<!--- Should be tested on Chrome, Firefox, and IE. -->
- [x] Chrome
- [ ] Firefox
- [ ] IE
- [ ] Edge
