### PR TITLE
fix: invalid element state error on assign to team

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -1064,6 +1064,8 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                     if (toggleButton.Text == "Me")
                         toggleButton.Click();
 
+                    driver.WaitForTransaction();
+
                     //Set the User Or Team
                     var userOrTeamField = driver.WaitUntilAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.TextFieldLookup]), "User field unavailable");
                     var input = userOrTeamField.ClickWhenAvailable(By.TagName("input"), "User field unavailable");
@@ -1224,7 +1226,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             {
                 //Find the button in the CommandBar
                 var ribbon = driver.WaitUntilAvailable(By.XPath(AppElements.Xpath[AppReference.CommandBar.Container]),
-                    TimeSpan.FromSeconds(5));
+            TimeSpan.FromSeconds(5));
 
                 if (ribbon == null)
                 {
@@ -4522,9 +4524,9 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 //SetValue(Elements.ElementId[AppReference.Dialogs.CloseOpportunity.DescriptionId], description);
 
                 driver.ClickWhenAvailable(By.XPath(AppElements.Xpath[AppReference.Dialogs.CloseOpportunity.Ok]),
-                    TimeSpan.FromSeconds(5),
-                    "The Close Opportunity dialog is not available."
-                );
+            TimeSpan.FromSeconds(5),
+            "The Close Opportunity dialog is not available."
+        );
 
                 return true;
             });


### PR DESCRIPTION
### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Description
Added a `driver.WaitForTransaction()` call before clicking into the search box.

### Issues addressed
Previously, the `input.SendKeys(userOrTeamName, true);` line would occasionally fail on clearing the field with an invalid element state exception. Adding a `WaitForTransaction()` after toggling to 'User or Team' seems to fix that.

### All submissions:

- [x] My code follows the code style of this project.
- [x] Do existing samples that are effected by this change still run?
- [x] I have added samples for new functionality. 
- [x] I raise detailed error messages when possible.
- [x] My code does not rely on labels that have the option to be hidden.

### Which browsers was this tested on?
<!--- Should be tested on Chrome, Firefox, and IE. -->
- [x] Chrome
- [ ] Firefox
- [ ] IE
- [ ] Edge
