### PR TITLE
Fix id reading for get grid items

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -1194,7 +1194,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             var xpathToItems = By.XPath(AppElements.Xpath[AppReference.Entity.LookupFieldResultListItem].Replace("[NAME]", name));
 
             //wait for complete the search
-            container.WaitUntil(d => d.FindVisible(By.XPath(".//li/div/label/span"))?.Text?.Contains(control.Value, StringComparison.OrdinalIgnoreCase) == true);
+            container.WaitUntil(d => d.FindVisible(xpathToItems)?.Text?.Contains(control.Value, StringComparison.OrdinalIgnoreCase) == true);
 
             ICollection<IWebElement> result = container.WaitUntil(
                 d => d.FindElements(xpathToItems),
@@ -2386,7 +2386,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             if (found)
                 SetInputValue(driver, input, value);
 
-            TrySetValue(fieldContainer, control);
+            TrySetValue(driver, control);
         }
 
         /// <summary>

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -1580,7 +1580,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 
                             foreach (var header in rowHeaders)
                             {
-                                var id = header.GetAttribute("id");
+                                var id = header.GetAttribute("data-id") ?? header.GetAttribute("id");
                                 var className = header.GetAttribute("class");
                                 var cellData = cells[currentindex + 1].GetAttribute("title");
 


### PR DESCRIPTION
### Type of change

- [+] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (updates to documentation, formatting, etc.)

### Description
With UIAutomation.Api.UCI the attribute "XXXX" is actually a random variation "Gride21f0827-f2ab-f51c-a3dc-91d4dd33e3fd-XXXX".
Use by default "data-id" attribute instead of "id", because it always contains a unique value. And for compatibility use the "id" attribute if the "data-id" attribute does not exist.

### Issues addressed
#903

### All submissions:

- [+] My code follows the code style of this project.
- [+] Do existing samples that are affected by this change still run?
- [ ] I have added samples for new functionality. 
- [ ] I raise detailed error messages when possible.
- [+] My code does not rely on labels that have the option to be hidden.

### Which browsers was this tested on?
<!--- Should be tested on Chrome, Firefox, and IE. -->
- [+] Chrome
- [ ] Firefox
- [ ] IE
- [ ] Edge
