### PR TITLE
Fix Field.IsReadOnly for an input field

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/Controls/Field.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/Controls/Field.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                     // DateTime condition
                     var readOnlyInput = containerElement.FindElement(By.TagName("input"));
 
-                    if (readOnlyInput.HasAttribute("disabled"))
+                    if (readOnlyInput.HasAttribute("disabled") || readOnlyInput.HasAttribute("readonly"))
                         return true;
                 }
                 else


### PR DESCRIPTION
### Type of change

- [+] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (updates to documentation, formatting, etc.)

### Description
Field.IsReadOnly always returns false for an input field on Cannary. We should also check readOnlyInput.HasAttribute("readonly")

### Issues addressed
#1023 
#1050 

### All submissions:

- [+] My code follows the code style of this project.
- [+] Do existing samples that are affected by this change still run?
- [ ] I have added samples for new functionality. 
- [ ] I raise detailed error messages when possible.
- [+] My code does not rely on labels that have the option to be hidden.

### Which browsers was this tested on?
<!--- Should be tested on Chrome, Firefox, and IE. -->
- [+] Chrome
- [ ] Firefox
- [ ] IE
- [ ] Edge
