### PR TITLE
Fix open Performance Widget when performance issues exist

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/AppElementReference.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/AppElementReference.cs
@@ -600,7 +600,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             { "Lookup_RecordList", ".//div[contains(@id,'RecordList') and contains(@role,'presentation')]" },
 
             //Performance Width
-            { "Performance_Widget","//div[@data-id='performance-widget']/div"},
+            { "Performance_Widget","//div[@data-id='performance-widget']//*[text()='Page load']"},
             { "Performance_WidgetPage", "//div[@data-id='performance-widget']//span[contains(text(), '[NAME]')]" }
         };
     }


### PR DESCRIPTION
### Type of change

- [+] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (updates to documentation, formatting, etc.)

### Description
Performance Widget is opened on the settings tab when performance issues exist. Issue reproduced sometimes because "Warnings" link appeared and disappeared during widget loading.
Problem that we perform click on first div ({ "Performance_Widget","//div[@data-id='performance-widget']/div"}), but it is not always correct item to invoke Performance Widget on metrics tab. Click on "Page load" text instead of div will fix the issue.

### Issues addressed
#1055 

### All submissions:

- [+] My code follows the code style of this project.
- [+] Do existing samples that are affected by this change still run?
- [ ] I have added samples for new functionality. 
- [ ] I raise detailed error messages when possible.
- [+] My code does not rely on labels that have the option to be hidden.

### Which browsers was this tested on?
<!--- Should be tested on Chrome, Firefox, and IE. -->
- [+] Chrome
- [ ] Firefox
- [ ] IE
- [ ] Edge
