### PR TITLE
Fix Remove Lookup Value when quickly clear many lookup fields

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -4079,6 +4079,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 throw new InvalidOperationException($"Field '{controlName}' does not contain a record with the name:  {value}");
 
             existingValue.Click(true);
+            driver.WaitForTransaction();
         }
 
         internal BrowserCommandResult<bool> ClearValue(OptionSet control, FormContextType formContextType)


### PR DESCRIPTION
### Type of change

- [+] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (updates to documentation, formatting, etc.)

### Description
ClearValue for LookupItem sometimes does not work when clear many lookup fields due fieldContainer.Hover(driver); do not work.
Added driver.WaitForTransaction(); to complete previous changes before Hover on a new looup.

### Issues addressed
#1069 

### All submissions:

- [+] My code follows the code style of this project.
- [+] Do existing samples that are affected by this change still run?
- [ ] I have added samples for new functionality. 
- [ ] I raise detailed error messages when possible.
- [+] My code does not rely on labels that have the option to be hidden.

### Which browsers was this tested on?
<!--- Should be tested on Chrome, Firefox, and IE. -->
- [+] Chrome
- [ ] Firefox
- [ ] IE
- [ ] Edge
