### PR TITLE
Dev/zwuai/uci open app fix

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -367,17 +367,15 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                     success = TryToClickInAppTile(appName, driver);
                 }
 
+                else if (driver.Url.Contains("forceUCI=1"))
+                {
+                    success = TryOpenAppFromMenu(driver, appName, AppReference.Navigation.UCIAppMenuButton);
+                }
                 else
                 {
-                    if (driver.Url.Contains("forceUCI=1"))
-                    {
-                        success = TryOpenAppFromMenu(driver, appName, AppReference.Navigation.UCIAppMenuButton);
-                    }
-                    else
-                    {
-                        success = TryOpenAppFromMenu(driver, appName, AppReference.Navigation.WebAppMenuButton);
-                    }
+                    success = TryOpenAppFromMenu(driver, appName, AppReference.Navigation.WebAppMenuButton);
                 }
+
 
                 if (!success)
                     throw new InvalidOperationException($"App Name {appName} not found.");

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -1,7 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+using Microsoft.Dynamics365.UIAutomation.Api.UCI.DTO;
+using Microsoft.Dynamics365.UIAutomation.Browser;
 using OpenQA.Selenium;
+using OpenQA.Selenium.Interactions;
+using OtpNet;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -10,10 +14,6 @@ using System.Linq;
 using System.Security;
 using System.Threading;
 using System.Web;
-using OpenQA.Selenium.Interactions;
-using OtpNet;
-using Microsoft.Dynamics365.UIAutomation.Api.UCI.DTO;
-using Microsoft.Dynamics365.UIAutomation.Browser;
 
 namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 {
@@ -360,11 +360,24 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             {
                 driver.WaitForPageToLoad();
                 driver.SwitchTo().DefaultContent();
-
+                var success = false;
                 //Handle left hand Nav in Web Client
-                var success = TryToClickInAppTile(appName, driver) ||
-                              TryOpenAppFromMenu(driver, appName, AppReference.Navigation.WebAppMenuButton) ||
-                              TryOpenAppFromMenu(driver, appName, AppReference.Navigation.UCIAppMenuButton);
+                if (!driver.Url.Contains("appid"))
+                {
+                    success = TryToClickInAppTile(appName, driver);
+                }
+
+                else
+                {
+                    if (driver.Url.Contains("forceUCI=1"))
+                    {
+                        success = TryOpenAppFromMenu(driver, appName, AppReference.Navigation.UCIAppMenuButton);
+                    }
+                    else
+                    {
+                        success = TryOpenAppFromMenu(driver, appName, AppReference.Navigation.WebAppMenuButton);
+                    }
+                }
 
                 if (!success)
                     throw new InvalidOperationException($"App Name {appName} not found.");


### PR DESCRIPTION
### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Other (updates to documentation, formatting, etc.)

### Description
Refactored OpenApp method to only run the relevant app selection method, rather than all 3 consecutively. This was previously causing up to a 1 minute wait on UCI instances with a default app opened.

### Issues addressed
This was previously causing up to a 1 minute wait on UCI instances with a default app opened.

### All submissions:

- [X] My code follows the code style of this project.
- [X] Do existing samples that are effected by this change still run?
- [X] I have added samples for new functionality. 
- [X] I raise detailed error messages when possible.
- [X] My code does not rely on labels that have the option to be hidden.

### Which browsers was this tested on?
<!--- Should be tested on Chrome, Firefox, and IE. -->
- [X] Chrome
- [X] Firefox
- [X] IE
- [X] Edge
