### PR TITLE
Update webclient for mfa validation

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -160,14 +160,17 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             }
 
             int attempts = 0;
-            bool entered;
-            do
+            bool entered=false;
+            if (mfaSecretKey != null)
             {
-                entered = EnterOneTimeCode(driver, mfaSecretKey);
-                success = ClickStaySignedIn(driver) || IsUserAlreadyLogged();
-                attempts++;
+                do
+                {
+                    entered = EnterOneTimeCode(driver, mfaSecretKey);
+                    success = ClickStaySignedIn(driver) || IsUserAlreadyLogged();
+                    attempts++;
+                }
+                while (!success && attempts <= Constants.DefaultRetryAttempts); // retry to enter the otc-code, if its fail & it is requested again 
             }
-            while (!success && attempts <= Constants.DefaultRetryAttempts); // retry to enter the otc-code, if its fail & it is requested again 
 
             if (entered && !success)
                 throw new InvalidOperationException("Something went wrong entering the OTC. Please check the MFA-SecretKey in configuration.");


### PR DESCRIPTION
Validate null value on MFA before executing the do-while.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

### Description
Updated Login to validate if MFA value is null before executing the following action (do-while) to enter the OTC

### Issues addressed
<!--- Why is this change required? What problem does it solve? -->
For some reason even if we are not using OTC on the online version, it steps into the do-while and ends up throwing the error:
"Something went wrong entering the OTC".

### All submissions:

- [ ] My code follows the code style of this project.
- [ ] Do existing samples that are effected by this change still run?
- [ ] I raise detailed error messages when possible.
- [ ] My code does not rely on labels that have the option to be hidden.

### Which browsers was this tested on?
<!--- Should be tested on Chrome, Firefox, and IE. -->
- [ ] Chrome
