### PR TITLE
Fix for subgrid click command (issue 1087)

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -1995,7 +1995,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                     // Locate subGrid command list
                     //var foundCommands = subGrid.TryFindElement(By.XPath(AppElements.Xpath[AppReference.Entity.SubGridList].Replace("[NAME]", subgridName)), out subGridRecordList);
 
-                    var items = subGridCommandBar.FindElements(By.TagName("li"));
+                    var items = subGridCommandBar.FindElements(By.TagName("button"));
 
                     //Is the button in the ribbon?
                     if (items.Any(x => x.GetAttribute("aria-label").Equals(name, StringComparison.OrdinalIgnoreCase)))


### PR DESCRIPTION
### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (updates to documentation, formatting, etc.)

### Description
XPath changes have broken the ClickCommand method.
This pull request fixes the ClickCommand method when run against a subgrid.

### Issues addressed
#1087

### All submissions:

- [x] My code follows the code style of this project.
- [ ] Do existing samples that are effected by this change still run?
- [ ] I have added samples for new functionality. 
- [ ] I raise detailed error messages when possible.
- [x] My code does not rely on labels that have the option to be hidden.

### Which browsers was this tested on?
<!--- Should be tested on Chrome, Firefox, and IE. -->
- [x] Chrome
- [ ] Firefox
- [ ] IE
- [ ] Edge
