### PR TITLE
Project can't be builded because of careless mistake

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/Controls/Field.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/Controls/Field.cs
@@ -97,7 +97,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 else if (containerElement.HasElement(By.TagName("textarea")))
                 {
                     var readOnlyTextArea = containerElement.FindElement(By.TagName("textarea"));
-                    return readOnlyTextArea.HasAttribute("readonly"))
+                    return readOnlyTextArea.HasAttribute("readonly");
                 }
                 else
                 {


### PR DESCRIPTION
### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (updates to documentation, formatting, etc.)

### Description
<!--- Describe your changes -->

### Issues addressed
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### All submissions:

- [ ] My code follows the code style of this project.
- [ ] Do existing samples that are effected by this change still run?
- [ ] I have added samples for new functionality. 
- [ ] I raise detailed error messages when possible.
- [ ] My code does not rely on labels that have the option to be hidden.

### Which browsers was this tested on?
<!--- Should be tested on Chrome, Firefox, and IE. -->
- [ ] Chrome
- [ ] Firefox
- [ ] IE
- [ ] Edge

I saw an error that caused project being not buildable.

**Solution**
delete one parenthesis and added semicolon