### PR TITLE
Resolved dialog context not found and added feature select tab and click command on dialog

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/AppElementReference.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/AppElementReference.cs
@@ -182,6 +182,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         public static class CommandBar
         {
             public static string Container = "Cmd_Container";
+            public static string DialogContainer = "Cmd_DialogContainer";
             public static string ContainerGrid = "Cmd_ContainerGrid";
             public static string MoreCommandsMenu = "Cmd_MoreCommandsMenu";
             public static string Button = "Cmd_Button";
@@ -418,7 +419,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             { "Entity_RecordSetNavList", "//ul[contains(@data-id, 'recordSetNavList')]" },
             { "Entity_RecordSetNavCollapseIcon", "//*[contains(@data-id, 'recordSetNavCollapseIcon')]" },
             { "Entity_RecordSetNavCollapseIconParent", "//*[contains(@data-id, 'recordSetNavCollapseIcon')]" },
-            { "Entity_TabList", "//ul[contains(@id, \"tablist\")]" },
+            { "Entity_TabList", ".//ul[contains(@id, \"tablist\")]" },
             { "Entity_Tab", ".//li[@title='{0}']" },
             { "Entity_MoreTabs", ".//button[@data-id='more_button']" },
             { "Entity_MoreTabsMenu", "//div[@id='__flyoutRootNode']" },
@@ -492,7 +493,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             { "Entity_Header_DateTimeFieldContainer","//div[@data-id='header_[NAME]-FieldSectionItemContainer']" },
                         
             //CommandBar
-            { "Cmd_Container"       , "//ul[contains(@data-lp-id,\"commandbar-Form\")]"},
+            { "Cmd_Container"       , ".//ul[contains(@data-lp-id,\"commandbar-Form\")]"},
             { "Cmd_ContainerGrid"       , "//ul[contains(@data-lp-id,\"commandbar-HomePageGrid\")]"},
             { "Cmd_MoreCommandsMenu"       , "//*[@id=\"__flyoutRootNode\"]"},
             { "Cmd_Button", "//*[contains(text(),'[NAME]')]"},
@@ -548,7 +549,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             { "BPF_CloseStageButton","//button[contains(@id,'stageContentClose')]"},
 
             //Related Grid
-            { "Related_CommandBarButton", ".//li[contains(@aria-label, '[NAME]') and contains(@id,'SubGrid')]//button"},
+            { "Related_CommandBarButton", ".//button[contains(@aria-label, '[NAME]') and contains(@id,'SubGrid')]"},
             { "Related_CommandBarOverflowContainer", "//div[contains(@data-id, 'flyoutRootNode')]"},
             { "Related_CommandBarOverflowButton", ".//button[contains(@data-id, 'OverflowButton') and contains(@data-lp-id, 'SubGridAssociated')]"},
             { "Related_CommandBarSubButton" ,".//button[contains(., '[NAME]')]"},
@@ -567,7 +568,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             { "CloseOpportunityDialog_CancelButton" , "//button[contains(@data-id, 'cancel_id')]" },
             { "CloseActivityDialog_CloseButton" , ".//button[contains(@data-id, 'ok_id')]" },
             { "CloseActivityDialog_CancelButton" , ".//button[contains(@data-id, 'cancel_id')]" },
-            { "Dialog_DialogContext", "//div[contains(@id,'dialogView') and contains(@role, 'dialog')]" },
+            { "Dialog_DialogContext", "//div[contains(@role, 'dialog')]" },
             { "Dialog_ActualRevenue", "//input[contains(@data-id,'actualrevenue_id')]" },
             { "Dialog_CloseDate", "//input[contains(@data-id,'closedate_id')]" },
             { "Dialog_DescriptionId", "//input[contains(@data-id,'description_id')]" },

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/AppElementReference.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/AppElementReference.cs
@@ -182,7 +182,6 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         public static class CommandBar
         {
             public static string Container = "Cmd_Container";
-            public static string DialogContainer = "Cmd_DialogContainer";
             public static string ContainerGrid = "Cmd_ContainerGrid";
             public static string MoreCommandsMenu = "Cmd_MoreCommandsMenu";
             public static string Button = "Cmd_Button";

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/Elements/Dialog.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/Elements/Dialog.cs
@@ -190,5 +190,17 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         {
             return _client.SetStateDialog(clickOkButton);
         }
+
+        /// <summary>
+        /// Clicks on entity dialog ribbon button
+        /// </summary>
+        /// <param name="buttonname"></param>
+        /// <param name="subButtonName"></param>
+        /// <param name="secondSubButtonName"></param>
+        /// <returns></returns>
+        public bool ClickCommand(string buttonName, string subButtonName = null, string secondSubButtonName = null)
+        {
+            return _client.ClickCommand(buttonName, subButtonName, secondSubButtonName);
+        }
     }
 }

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/Elements/Dialog.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/Elements/Dialog.cs
@@ -202,5 +202,16 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         {
             return _client.ClickCommand(buttonName, subButtonName, secondSubButtonName);
         }
+
+        /// <summary>
+        /// Clicks on entity dialog ribbon button
+        /// </summary>
+        /// <param name="tabName"></param>
+        /// <param name="subtabName"></param>
+        /// <returns></returns>
+        public bool SelectTab(string tabName, string subtabName = null)
+        {
+            return _client.SelectTab(tabName, subtabName);
+        }
     }
 }

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/Elements/Dialog.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/Elements/Dialog.cs
@@ -194,10 +194,10 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         /// <summary>
         /// Clicks on entity dialog ribbon button
         /// </summary>
-        /// <param name="buttonname"></param>
-        /// <param name="subButtonName"></param>
         /// <param name="secondSubButtonName"></param>
-        /// <returns></returns>
+        /// <param name="buttonName">Name of button to click</param>
+        /// <param name="subButtonName">Name of button on submenu to click</param>
+        /// <param name="secondSubButtonName">Name of button on submenu (3rd level) to click</param>
         public bool ClickCommand(string buttonName, string subButtonName = null, string secondSubButtonName = null)
         {
             return _client.ClickCommand(buttonName, subButtonName, secondSubButtonName);
@@ -206,9 +206,8 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         /// <summary>
         /// Clicks on entity dialog ribbon button
         /// </summary>
-        /// <param name="tabName"></param>
-        /// <param name="subtabName"></param>
-        /// <returns></returns>
+        /// <param name="tabName">The name of the tab based on the References class</param>
+        /// <param name="subtabName">The name of the subtab based on the References class</param>
         public bool SelectTab(string tabName, string subtabName = null)
         {
             return _client.SelectTab(tabName, subtabName);

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/Elements/Entity.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/Elements/Entity.cs
@@ -398,6 +398,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         /// Opens any tab on the web page.
         /// </summary>
         /// <param name="tabName">The name of the tab based on the References class</param>
+        /// <param name="subtabName">The name of the subtab based on the References class</param>
         public void SelectTab(string tabName, string subTabName = "")
         {
             _client.SelectTab(tabName, subTabName);

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -1224,9 +1224,19 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         {
             return Execute(GetOptions($"Click Command"), driver =>
             {
-                //Find the button in the CommandBar
-                var ribbon = driver.WaitUntilAvailable(By.XPath(AppElements.Xpath[AppReference.CommandBar.Container]),
-            TimeSpan.FromSeconds(5));
+                // Find the button in the CommandBar
+                IWebElement ribbon;
+                // Checking if any dialog is active
+                if (driver.HasElement(By.XPath(string.Format(AppElements.Xpath[AppReference.Dialogs.DialogContext]))))
+                {
+                    var dialogContainer = driver.FindElement(By.XPath(string.Format(AppElements.Xpath[AppReference.Dialogs.DialogContext])));
+                    ribbon = dialogContainer.WaitUntilAvailable(By.XPath(string.Format(AppElements.Xpath[AppReference.CommandBar.Container])));
+                }
+                else
+                {
+                    ribbon = driver.WaitUntilAvailable(By.XPath(AppElements.Xpath[AppReference.CommandBar.Container]));
+                }
+                TimeSpan.FromSeconds(5);
 
                 if (ribbon == null)
                 {
@@ -1236,7 +1246,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 }
 
                 //Get the CommandBar buttons
-                var items = ribbon.FindElements(By.TagName("li"));
+                var items = ribbon.FindElements(By.TagName("button"));
 
                 //Is the button in the ribbon?
                 if (items.Any(x => x.GetAttribute("aria-label").Equals(name, StringComparison.OrdinalIgnoreCase)))
@@ -4523,8 +4533,8 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 //SetValue(Elements.ElementId[AppReference.Dialogs.CloseOpportunity.DescriptionId], description);
 
                 driver.ClickWhenAvailable(By.XPath(AppElements.Xpath[AppReference.Dialogs.CloseOpportunity.Ok]),
-            TimeSpan.FromSeconds(5),
-            "The Close Opportunity dialog is not available."
+        TimeSpan.FromSeconds(5),
+        "The Close Opportunity dialog is not available."
         );
 
                 return true;
@@ -4614,7 +4624,16 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 
             return this.Execute($"Select Tab", driver =>
             {
-                IWebElement tabList = driver.WaitUntilAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.TabList]));
+                IWebElement tabList;
+                if (driver.HasElement(By.XPath(AppElements.Xpath[AppReference.Dialogs.DialogContext])))
+                {
+                    var dialogContainer = driver.FindElement(By.XPath(AppElements.Xpath[AppReference.Dialogs.DialogContext]));
+                    tabList = dialogContainer.WaitUntilAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.TabList]));
+                }
+                else
+                {
+                    tabList = driver.WaitUntilAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.TabList]));
+                }
 
                 ClickTab(tabList, AppElements.Xpath[AppReference.Entity.Tab], tabName);
 


### PR DESCRIPTION
### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (updates to documentation, formatting, etc.)

### Description
<!--- Describe your changes -->
Added a check for dialog on Select Tab and click command, if dialog is active click on dialog ribbon button or select tab on dialog else on main page. Also changed the xpath for dialog context as it is not unique to all environment

### Issues addressed
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#1091 
#1092 


### All submissions:
- [x] My code follows the code style of this project.
- [ ] Do existing samples that are effected by this change still run?
- [ ] I have added samples for new functionality. 
- [ ] I raise detailed error messages when possible.
- [x] My code does not rely on labels that have the option to be hidden.

### Which browsers was this tested on?
<!--- Should be tested on Chrome, Firefox, and IE. -->
- [x] Chrome
- [ ] Firefox
- [ ] IE
- [ ] Edge
