### PR TITLE
Fix GetGridItems command for bug #1096

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -1601,13 +1601,14 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                                 if (!string.IsNullOrEmpty(id)
                                     && className.Contains("wj-cell")
                                     && !string.IsNullOrEmpty(cellData)
+                                    && !id.Contains("btnheaderselectcolumn")
                                     && cells.Count > currentindex
                                 )
                                 {
                                     item[id] = cellData.Replace("-", "");
+                                    currentindex++;
                                 }
 
-                                currentindex++;
                             }
 
                             returnList.Add(item);


### PR DESCRIPTION
### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (updates to documentation, formatting, etc.)

### Description
<!--- Describe your changes -->
There is a certain number of columns and a certain number of cells for each row.

Until now, the problem was that there were more columns than individual cells of a single record, precisely because of the column "_btnheaderselectcolumn_".

And the first cell value, such as the Lead name, was always assigned to column _btnheaderselectcolumn_ but should have been assigned to column e.g. _lead_id_.

I added condition, that checks if column ID contains _btnheaderselectcolumn_, to skip this assignment.

Here is picture with final data. I have 3 records with some unfilled fields.
![image](https://user-images.githubusercontent.com/58347555/109330693-3ff0c480-785c-11eb-856c-8bfb3a16f8c2.png)

### Issues addressed
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### All submissions:

- [ ] My code follows the code style of this project.
- [ ] Do existing samples that are effected by this change still run?
- [ ] I have added samples for new functionality. 
- [ ] I raise detailed error messages when possible.
- [ ] My code does not rely on labels that have the option to be hidden.

### Which browsers was this tested on?
<!--- Should be tested on Chrome, Firefox, and IE. -->
- [ ] Chrome
- [ ] Firefox
- [ ] IE
- [ ] Edge
