### PR TITLE
fix: pick an account and firefox options

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/ElementReference.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/ElementReference.cs
@@ -316,6 +316,8 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             { "Process_Category", "WorkflowCategory"},
             { "Process_Entity", "PrimaryEntity"},
 
+            //Login
+            { "Login_UseAnotherAccount", "otherTile" }
     };
 
         public static Dictionary<string, string> CssClass = new Dictionary<string, string>()
@@ -733,6 +735,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             public static string CrmUCIMainPage = "Login_CrmUCIMainPage";
             public static string StaySignedIn = "Login_StaySignedIn";
             public static string OneTimeCode = "Login_OneTimeCode";
+            public static string UseAnotherAccount = "Login_UseAnotherAccount";
         }
         public static class Report
         {

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -120,7 +120,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             if (!online)
                 return LoginResult.Success;
 
-            driver.ClickIfVisible(By.Id("use_another_account_link"));
+            driver.ClickIfVisible(By.Id(Elements.ElementId[Reference.Login.UseAnotherAccount]));
 
             bool waitingForOtc = false;
             bool success = EnterUserName(driver, username);

--- a/Microsoft.Dynamics365.UIAutomation.Browser/BrowserDriverFactory.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Browser/BrowserDriverFactory.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Browser
                 case BrowserType.Firefox:
                     var ffService = FirefoxDriverService.CreateDefaultService(options.DriversPath);
                     ffService.HideCommandPromptWindow = options.HideDiagnosticWindow;
-                    driver = new FirefoxDriver(ffService);
+                    driver = new FirefoxDriver(ffService, options.ToFireFox());
                     driver.Manage().Timeouts().ImplicitWait = new TimeSpan(0, 0, 5);
                     break;
                 case BrowserType.Edge:


### PR DESCRIPTION
### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (updates to documentation, formatting, etc.)

### Description
Fixed an issue with the incorrect element ID being used for the "Use another account" login dialog. This causes issues when the particular browser has user details cached. For context, we are using chrome profiles to cache parts of D365 and significantly reduce the amount of time it takes each of our test cases to login.

Fixed an issue where the browser options are not actually passed to the Firefox driver, this prevents the passing of custom arguments (like setting the profile directory). For reference, these custom arguments can be set by overriding the "ToFirefox" method.


### Issues addressed
Addressed above.

### All submissions:

- [x] My code follows the code style of this project.
- [x] Do existing samples that are affected by this change still run?
- [ ] I have added samples for new functionality. 
- [x] I raise detailed error messages when possible.
- [x] My code does not rely on labels that have the option to be hidden.

### Which browsers was this tested on?
<!--- Should be tested on Chrome, Firefox, and IE. -->
- [x] Chrome
- [x] Firefox
- [ ] IE
- [ ] Edge
