### PR TITLE
Update Constants to support german online environments

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Browser/Constants.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Browser/Constants.cs
@@ -97,7 +97,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Browser
                 ".crm.dynamics.com", ".crm2.dynamics.com", ".crm3.dynamics.com",
                 ".crm4.dynamics.com", "crm5.dynamics.com", "crm6.dynamics.com", "crm7.dynamics.com",
                 ".crm8.dynamics.com", ".crm9.dynamics.com", ".crm10.dynamics.com", ".crm11.dynamics.com",
-                ".crm12.dynamics.com", ".crm15.dynamics.com", "portal.office.com", "crm2.crmlivetie.com", ".crm.microsoftdynamics.us", "portal.office365.us"
+                ".crm12.dynamics.com", ".crm14.dynamics.com", ".crm15.dynamics.com", ".crm16.dynamics.com", ".crm17.dynamics.com", "portal.office.com", "crm2.crmlivetie.com", ".crm.microsoftdynamics.us", "portal.office365.us"
             };
         }
 


### PR DESCRIPTION
The suffix for german online environments is ".crm16.dynamics.com", so in order to make the login work, it should be added to the constants.

Also crm14 for ZAF and crm17 for CHE.

Refer to the official documentation: https://docs.microsoft.com/en-us/power-platform/admin/new-datacenter-regions

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (updates to documentation, formatting, etc.)

### Description
<!--- Describe your changes -->

### Issues addressed
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### All submissions:

- [x] My code follows the code style of this project.
- [ ] Do existing samples that are effected by this change still run?
- [ ] I have added samples for new functionality. 
- [ ] I raise detailed error messages when possible.
- [ ] My code does not rely on labels that have the option to be hidden.

### Which browsers was this tested on?
<!--- Should be tested on Chrome, Firefox, and IE. -->
- [x] Chrome
- [ ] Firefox
- [ ] IE
- [ ] Edge
