### PR TITLE
fix error: get div element instead of label in BPF to open BPF container

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -4942,14 +4942,14 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 
                 foreach (var processStage in processStages)
                 {
-                    var labels = processStage.FindElements(By.TagName("label"));
+                    var divs = processStage.FindElements(By.TagName("div"));
 
                     //Click the Label of the Process Stage if found
-                    foreach (var label in labels)
+                    foreach (var div in divs)
                     {
-                        if (label.Text.Equals(stageName, StringComparison.OrdinalIgnoreCase))
+                        if (div.Text.Equals(stageName, StringComparison.OrdinalIgnoreCase))
                         {
-                            label.Click();
+                            div.Click();
                         }
                     }
                 }


### PR DESCRIPTION
### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (updates to documentation, formatting, etc.)

### Description
<!--- Describe your changes -->

### Issues addressed
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### All submissions:

- [X] My code follows the code style of this project.
- [ ] Do existing samples that are effected by this change still run?
- [ ] I have added samples for new functionality. 
- [ ] I raise detailed error messages when possible.
- [ ] My code does not rely on labels that have the option to be hidden.

### Which browsers was this tested on?
<!--- Should be tested on Chrome, Firefox, and IE. -->
- [X] Chrome
- [ ] Firefox
- [ ] IE
- [ ] Edge

#1160 