### PR TITLE
Update to Grid.cs and xrmPage.cs- added FilterByLetter and SwitchToMainWindow() method

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/Elements/Grid.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/Elements/Grid.cs
@@ -77,5 +77,14 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         {
             _client.Sort(columnName, sortOptionButtonText);
         }
+
+        /// <summary>
+        /// Filter the grid by the Character provided
+        /// </summary>
+        /// <param name="filter">Label of footer filter - View records that starts with this letter</param>
+        public void FilterByLetter(char filter)
+        {
+            _client.FilterByLetter(filter);
+        }
     }
 }

--- a/Microsoft.Dynamics365.UIAutomation.Api/XrmPage.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api/XrmPage.cs
@@ -1446,5 +1446,21 @@ namespace Microsoft.Dynamics365.UIAutomation.Api
 
         }
 
+        internal bool SwitchToMain()
+        {
+            Browser.ThinkTime(3000);
+            Browser.Driver.LastWindow().SwitchTo().DefaultContent();
+            return true;
+        }
+
+        /// <summary>
+        /// Switches to Main Window from any other Pop-Up Window
+        /// </summary>
+        public bool SwitchToMainWindow()
+        {
+
+            return this.Execute("Switch to Main Window", driver => SwitchToMain());
+        }
+
     }
 }


### PR DESCRIPTION
### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

- [x] New feature (non-breaking change which adds functionality)

- [ ] Other (updates to documentation, formatting, etc.)

### Description
Added FilterByLetter method to provide capability to filter the view by first letter.
This uses the OOB filter view by first letter feature available in footer of all the views.

Added method for switching back to main CRM window when control is on any custom Pop-up window.
SwitchToMainWindow()

### Issues addressed
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Unable to filter the view by First letter using the OOB footer links available to filter the view using first character.
Unable to switch to Main CRM window from custom pop-up window.

### All submissions:

- [x] My code follows the code style of this project.
- [ ] Do existing samples that are effected by this change still run?
- [ ] I have added samples for new functionality. 
- [ ] I raise detailed error messages when possible.
- [ ] My code does not rely on labels that have the option to be hidden.

### Which browsers was this tested on?
<!--- Should be tested on Chrome, Firefox, and IE. -->
- [x] Chrome
- [ ] Firefox
- [ ] IE
- [ ] Edge
