### PR TITLE
2021 RW 1. Added Click for cell object in OpenRecord

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -1544,6 +1544,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                     cell =>
                     {
                         var emptyDiv = cell.FindElement(By.TagName("div"));
+                        cell.Click();
                         driver.Perform(action, cell, cell.LeftTo(emptyDiv));
                     },
                     $"An error occur trying to open the record at position {index}"

--- a/Microsoft.Dynamics365.UIAutomation.Sample/Microsoft.Dynamics365.UIAutomation.Sample.csproj
+++ b/Microsoft.Dynamics365.UIAutomation.Sample/Microsoft.Dynamics365.UIAutomation.Sample.csproj
@@ -292,10 +292,10 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Selenium.Firefox.WebDriver.0.26.0\build\Selenium.Firefox.WebDriver.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Selenium.Firefox.WebDriver.0.26.0\build\Selenium.Firefox.WebDriver.targets'))" />
-    <Error Condition="!Exists('..\packages\Selenium.WebDriver.ChromeDriver.91.0.4472.1900\build\Selenium.WebDriver.ChromeDriver.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Selenium.WebDriver.ChromeDriver.91.0.4472.1900\build\Selenium.WebDriver.ChromeDriver.targets'))" />
+    <Error Condition="!Exists('..\packages\Selenium.WebDriver.ChromeDriver.93.0.4577.6300\build\Selenium.WebDriver.ChromeDriver.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Selenium.WebDriver.ChromeDriver.93.0.4577.6300\build\Selenium.WebDriver.ChromeDriver.targets'))" />
   </Target>
   <Import Project="..\packages\Selenium.Firefox.WebDriver.0.26.0\build\Selenium.Firefox.WebDriver.targets" Condition="Exists('..\packages\Selenium.Firefox.WebDriver.0.26.0\build\Selenium.Firefox.WebDriver.targets')" />
-  <Import Project="..\packages\Selenium.WebDriver.ChromeDriver.91.0.4472.1900\build\Selenium.WebDriver.ChromeDriver.targets" Condition="Exists('..\packages\Selenium.WebDriver.ChromeDriver.91.0.4472.1900\build\Selenium.WebDriver.ChromeDriver.targets')" />
+  <Import Project="..\packages\Selenium.WebDriver.ChromeDriver.93.0.4577.6300\build\Selenium.WebDriver.ChromeDriver.targets" Condition="Exists('..\packages\Selenium.WebDriver.ChromeDriver.93.0.4577.6300\build\Selenium.WebDriver.ChromeDriver.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Microsoft.Dynamics365.UIAutomation.Sample/UCI/Controls/Grid.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Sample/UCI/Controls/Grid.cs
@@ -26,5 +26,23 @@ namespace Microsoft.Dynamics365.UIAutomation.Sample.UCI
                 xrmApp.Grid.Sort("Main Phone", "Sort A to Z");
             }
         }
+
+        [TestMethod]
+        public void UCIGridOpenRecord()
+        {
+            var client = new WebClient(TestSettings.Options);
+            using (var xrmApp = new XrmApp(client))
+            {
+                xrmApp.OnlineLogin.Login(_xrmUri, _username, _password, _mfaSecretKey);
+
+                //xrmApp.Navigation.OpenApp(UCIAppName.Sales);
+
+                xrmApp.Navigation.OpenSubArea("Sales", "Accounts");
+
+                xrmApp.Grid.SwitchView("Active Accounts");
+
+                xrmApp.Grid.OpenRecord(0);
+            }
+        }
     }
 }

--- a/Microsoft.Dynamics365.UIAutomation.Sample/packages.config
+++ b/Microsoft.Dynamics365.UIAutomation.Sample/packages.config
@@ -7,7 +7,7 @@
   <package id="Selenium.Firefox.WebDriver" version="0.26.0" targetFramework="net46" />
   <package id="Selenium.Support" version="3.141.0" targetFramework="net46" />
   <package id="Selenium.WebDriver" version="3.141.0" targetFramework="net46" />
-  <package id="Selenium.WebDriver.ChromeDriver" version="91.0.4472.1900" targetFramework="net46" />
+  <package id="Selenium.WebDriver.ChromeDriver" version="93.0.4577.6300" targetFramework="net46" />
   <package id="System.Buffers" version="4.4.0" targetFramework="net46" />
   <package id="System.Diagnostics.DiagnosticSource" version="4.6.0" targetFramework="net46" />
   <package id="System.Memory" version="4.5.3" targetFramework="net46" />


### PR DESCRIPTION
### Type of change

- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (updates to documentation, formatting, etc.)

### Description
This is a fix for the RW1 2021 grid OpenRecord functionality. This is NOT for RW 2 and the PCF Grid.

### Issues addressed
The grid logic assumed an empty div element that does not exist. This fix will click the cell then perform the double click.
[#1190 ](https://github.com/microsoft/EasyRepro/issues/1190)
[#1188 ](https://github.com/microsoft/EasyRepro/issues/1188)


### All submissions:

- [X ] My code follows the code style of this project.
- [ X] Do existing samples that are effected by this change still run?
- [X ] I have added samples for new functionality. 
- [ X] I raise detailed error messages when possible.
- [ X] My code does not rely on labels that have the option to be hidden.

### Which browsers was this tested on?
<!--- Should be tested on Chrome, Firefox, and IE. -->
- [ X] Chrome 93
- [ ] Firefox
- [ ] IE
- [ ] Edge
