### PR TITLE
click on cell with checkbox to bypass hierarchical button

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/AppElementReference.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/DTO/AppElementReference.cs
@@ -59,6 +59,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             public static string HideChart = "Grid_HideChart";
             public static string JumpBar = "Grid_JumpBar";
             public static string FilterByAll = "Grid_FilterByAll";
+            public static string RowsContainerCheckbox = "Grid_RowsContainerCheckbox";
             public static string RowsContainer = "Grid_RowsContainer";
             public static string Rows = "Grid_Rows";
             public static string ChartSelector = "Grid_ChartSelector";
@@ -376,6 +377,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             { "Grid_ShowChart"       , "//button[contains(@aria-label,'Show Chart')]"},
             { "Grid_JumpBar"       , "//*[@id=\"JumpBarItemsList\"]"},
             { "Grid_FilterByAll"       , "//*[@id=\"All_link\"]"},
+            { "Grid_RowsContainerCheckbox"  ,   "//div[@role='checkbox']" },
             { "Grid_RowsContainer"       , "//div[contains(@role,'grid')]"},
             { "Grid_Rows"           , "//div[contains(@role,'row')]"},
             { "Grid_ChartSelector"           , "//span[contains(@id,'ChartSelector')]"},

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -1543,7 +1543,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 control.WaitUntilClickable(xpathToCell,
                     cell =>
                     {
-                        var emptyDiv = cell.FindElement(By.XPath("//div[@role='checkbox']"));
+                        var emptyDiv = cell.FindElement(By.XPath(AppElements.Xpath[AppReference.Grid.RowsContainerCheckbox]));
                         driver.Perform(action, cell, cell.LeftTo(emptyDiv));
                     },
                     $"An error occur trying to open the record at position {index}"

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -1543,8 +1543,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 control.WaitUntilClickable(xpathToCell,
                     cell =>
                     {
-                        var emptyDiv = cell.FindElement(By.TagName("div"));
-                        cell.Click();
+                        var emptyDiv = cell.FindElement(By.XPath("//div[@role='checkbox']"));
                         driver.Perform(action, cell, cell.LeftTo(emptyDiv));
                     },
                     $"An error occur trying to open the record at position {index}"

--- a/Microsoft.Dynamics365.UIAutomation.Sample/UCI/Controls/Grid.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Sample/UCI/Controls/Grid.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Sample.UCI
             {
                 xrmApp.OnlineLogin.Login(_xrmUri, _username, _password, _mfaSecretKey);
 
-                //xrmApp.Navigation.OpenApp(UCIAppName.Sales);
+                xrmApp.Navigation.OpenApp(UCIAppName.Sales);
 
                 xrmApp.Navigation.OpenSubArea("Sales", "Accounts");
 
@@ -53,13 +53,13 @@ namespace Microsoft.Dynamics365.UIAutomation.Sample.UCI
             {
                 xrmApp.OnlineLogin.Login(_xrmUri, _username, _password, _mfaSecretKey);
 
-                //xrmApp.Navigation.OpenApp(UCIAppName.Sales);
+                xrmApp.Navigation.OpenApp(UCIAppName.Sales);
 
                 xrmApp.Navigation.OpenSubArea("Sales", "Accounts");
 
                 xrmApp.Grid.SwitchView("My Active Accounts");
 
-                xrmApp.Grid.OpenRecord(0);
+                xrmApp.Grid.OpenRecord(1);
             }
         }
 
@@ -72,7 +72,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Sample.UCI
             {
                 xrmApp.OnlineLogin.Login(_xrmUri, _username, _password, _mfaSecretKey);
 
-                //xrmApp.Navigation.OpenApp(UCIAppName.Sales);
+                xrmApp.Navigation.OpenApp(UCIAppName.Sales);
 
                 xrmApp.Navigation.OpenSubArea("Sales", "Accounts");
 

--- a/Microsoft.Dynamics365.UIAutomation.Sample/UCI/Controls/Grid.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Sample/UCI/Controls/Grid.cs
@@ -39,9 +39,49 @@ namespace Microsoft.Dynamics365.UIAutomation.Sample.UCI
 
                 xrmApp.Navigation.OpenSubArea("Sales", "Accounts");
 
-                xrmApp.Grid.SwitchView("Active Accounts");
+                xrmApp.Grid.SwitchView("Customers");
 
                 xrmApp.Grid.OpenRecord(0);
+            }
+        }
+
+        [TestMethod]
+        public void UCIGridOpenRecordWithHierarchialRelationship()
+        {
+            var client = new WebClient(TestSettings.Options);
+            using (var xrmApp = new XrmApp(client))
+            {
+                xrmApp.OnlineLogin.Login(_xrmUri, _username, _password, _mfaSecretKey);
+
+                //xrmApp.Navigation.OpenApp(UCIAppName.Sales);
+
+                xrmApp.Navigation.OpenSubArea("Sales", "Accounts");
+
+                xrmApp.Grid.SwitchView("My Active Accounts");
+
+                xrmApp.Grid.OpenRecord(0);
+            }
+        }
+
+        [TestMethod]
+        public void UCITestOpenSubGridRecordOnAccount()
+        {
+            var client = new WebClient(TestSettings.Options);
+
+            using (var xrmApp = new XrmApp(client))
+            {
+                xrmApp.OnlineLogin.Login(_xrmUri, _username, _password, _mfaSecretKey);
+
+                //xrmApp.Navigation.OpenApp(UCIAppName.Sales);
+
+                xrmApp.Navigation.OpenSubArea("Sales", "Accounts");
+
+                xrmApp.Grid.OpenRecord(0);
+
+                // Reference schema name of the SubGrid
+                xrmApp.Entity.SubGrid.GetSubGridItems("Contacts");
+
+                xrmApp.ThinkTime(3000);
             }
         }
     }


### PR DESCRIPTION
### Type of change

- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (updates to documentation, formatting, etc.)

### Description
Fixing issue where hierarchy relationship button is pressed. The code now will look for cell with role of checkbox to perform action.

### Issues addressed
Fixing issue where hierarchy relationship button is pressed. 
[#1201 ](https://github.com/microsoft/EasyRepro/issues/1201)

### All submissions:

- [X ] My code follows the code style of this project.
- [ X] Do existing samples that are effected by this change still run?
- [X ] I have added samples for new functionality. 
- [ ] I raise detailed error messages when possible.
- [X ] My code does not rely on labels that have the option to be hidden.

### Which browsers was this tested on?
- [ X] Chrome
- [ ] Firefox
- [ ] IE
- [ ] Edge
