### PR TITLE
Fixes/fix click commandbar command (#1213)

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -1277,7 +1277,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 {
                     ribbon = driver.WaitUntilAvailable(By.XPath(AppElements.Xpath[AppReference.CommandBar.Container]));
                 }
-                TimeSpan.FromSeconds(5);
+                
 
                 if (ribbon == null)
                 {
@@ -1285,29 +1285,26 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                         TimeSpan.FromSeconds(5),
                         "Unable to find the ribbon.");
                 }
-
-                //Get the CommandBar buttons
-                var items = ribbon.FindElements(By.TagName("button"));
-
+                
                 //Is the button in the ribbon?
-                if (items.Any(x => x.GetAttribute("aria-label").Equals(name, StringComparison.OrdinalIgnoreCase)))
+                if (ribbon.TryFindElement(By.XPath(AppElements.Xpath[AppReference.Entity.SubGridCommandLabel].Replace("[NAME]", name)), out var command))
                 {
-                    items.FirstOrDefault(x => x.GetAttribute("aria-label").Equals(name, StringComparison.OrdinalIgnoreCase)).Click(true);
+                    command.Click(true);
                     driver.WaitForTransaction();
                 }
                 else
                 {
                     //Is the button in More Commands?
-                    if (items.Any(x => x.GetAttribute("aria-label").StartsWith("More Commands", StringComparison.OrdinalIgnoreCase)))
+                    if (ribbon.TryFindElement(By.XPath(AppElements.Xpath[AppReference.Entity.SubGridCommandLabel].Replace("[NAME]", "More Commands")), out var moreCommands))
                     {
-                        //Click More Commands
-                        items.FirstOrDefault(x => x.GetAttribute("aria-label").StartsWith("More Commands", StringComparison.OrdinalIgnoreCase)).Click(true);
+                        // Click More Commands
+                        moreCommands.Click(true);
                         driver.WaitForTransaction();
 
                         //Click the button
-                        if (driver.HasElement(By.XPath(AppElements.Xpath[AppReference.CommandBar.Button].Replace("[NAME]", name))))
+                        if (ribbon.TryFindElement(By.XPath(AppElements.Xpath[AppReference.Entity.SubGridOverflowButton].Replace("[NAME]", name)), out var overflowCommand))
                         {
-                            driver.FindElement(By.XPath(AppElements.Xpath[AppReference.CommandBar.Button].Replace("[NAME]", name))).Click(true);
+                            overflowCommand.Click(true);
                             driver.WaitForTransaction();
                         }
                         else
@@ -1321,7 +1318,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 {
                     var submenu = driver.WaitUntilAvailable(By.XPath(AppElements.Xpath[AppReference.CommandBar.MoreCommandsMenu]));
 
-                    var subbutton = submenu.FindElements(By.TagName("button")).FirstOrDefault(x => x.Text == subname);
+                    submenu.TryFindElement(By.XPath(AppElements.Xpath[AppReference.Entity.SubGridOverflowButton].Replace("[NAME]", subname)), out var subbutton);
 
                     if (subbutton != null)
                     {
@@ -1334,7 +1331,9 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                     {
                         var subSecondmenu = driver.WaitUntilAvailable(By.XPath(AppElements.Xpath[AppReference.CommandBar.MoreCommandsMenu]));
 
-                        var subSecondbutton = subSecondmenu.FindElements(By.TagName("button")).FirstOrDefault(x => x.Text == subSecondName);
+                        subSecondmenu.TryFindElement(
+                            By.XPath(AppElements.Xpath[AppReference.Entity.SubGridOverflowButton]
+                                .Replace("[NAME]", subSecondName)), out var subSecondbutton);
 
                         if (subSecondbutton != null)
                         {

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -1295,7 +1295,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 else
                 {
                     //Is the button in More Commands?
-                    if (ribbon.TryFindElement(By.XPath(AppElements.Xpath[AppReference.Entity.SubGridCommandLabel].Replace("[NAME]", "More Commands")), out var moreCommands))
+                    if (ribbon.TryFindElement(By.XPath(AppElements.Xpath[AppReference.Entity.SubGridCommandLabel].Replace("[NAME]", "More commands")), out var moreCommands))
                     {
                         // Click More Commands
                         moreCommands.Click(true);


### PR DESCRIPTION
### Type of change

- [+] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (updates to documentation, formatting, etc.)

### Description
Updates the selectors in use to find CommandBar buttons for Wave 2

### Issues addressed
Resolves #1212. A recent update has caused this functionality to break  for Wave 2

### All submissions:

- [+] My code follows the code style of this project.
- [ ] Do existing samples that are effected by this change still run?
- [ ] I have added samples for new functionality. 
- [ ] I raise detailed error messages when possible.
- [ ] My code does not rely on labels that have the option to be hidden.

### Which browsers was this tested on?
<!--- Should be tested on Chrome, Firefox, and IE. -->
- [+] Chrome
- [ ] Firefox
- [ ] IE
- [ ] Edge
