### PR TITLE
fix: get form state for read only forms

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -14,6 +14,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Resources;
 using System.Security;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Web;
 
@@ -3808,14 +3809,24 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             return this.Execute(GetOptions($"Get Status value from form"), driver =>
             {
                 driver.WaitForTransaction();
-
-                if (driver.TryFindElement(By.Id("message-formReadOnlyNotification"), out var readOnlyNotification))
-                {
-                    return readOnlyNotification.Text.Replace("Read-only This record’s status: ", string.Empty);
-                }
-                else
+                if (!driver.TryFindElement(By.Id("message-formReadOnlyNotification"), out var readOnlyNotification))
                 {
                     return "Active";
+                }
+
+                var match = Regex.Match(readOnlyNotification.Text, "This record’s status: (.*)");
+                if (match.Success)
+                {
+                    return match.Captures[1].Value;
+                }
+
+                try
+                {
+                    return GetHeaderValue(new OptionSet { Name = "statecode" }).Value;
+                }
+                catch (Exception ex)
+                {
+                    throw new NotFoundException("Unable to determine the status from the form. This can happen if you do not have access to edit the record and the state is not in the header.", ex);
                 }
             });
         }

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -2057,7 +2057,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                     else
                     {
                         // Is the button in More Commands overflow?
-                        if (subGridCommandBar.TryFindElement(By.XPath(AppElements.Xpath[AppReference.Entity.SubGridOverflowButton].Replace("[NAME]", "More commands")), out var moreCommands))
+                        if (subGridCommandBar.TryFindElement(By.XPath(AppElements.Xpath[AppReference.Entity.SubGridCommandLabel].Replace("[NAME]", "More Commands")), out var moreCommands))
                         {
                             // Click More Commands
                             moreCommands.Click(true);


### PR DESCRIPTION
Falls back to checking for a state in the header if the record is read-only. A read-only record does not show the record state notification.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (updates to documentation, formatting, etc.)

### Description
Falls back to looking for the state in the header if unable to determine the state from the form. 

### Issues addressed
A read-only notification on a record will take precedence over the notification that shows the state, so this offers a potential workaround.

### All submissions:

- [x] My code follows the code style of this project.
- [x] Do existing samples that are effected by this change still run?
- [x] I have added samples for new functionality. 
- [x] I raise detailed error messages when possible.
- [x] My code does not rely on labels that have the option to be hidden.

### Which browsers was this tested on?
<!--- Should be tested on Chrome, Firefox, and IE. -->
- [x] Chrome
- [ ] Firefox
- [ ] IE
- [ ] Edge
