### PR TITLE
fix: get dialog context with multiple dialogs

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -2358,7 +2358,10 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             else if (formContextType == FormContextType.Dialog)
             {
                 // Initialize the Dialog context
-                var formContext = driver.WaitUntilAvailable(By.XPath(AppElements.Xpath[AppReference.Dialogs.DialogContext]));
+                driver.WaitForTransaction();
+                var formContext = driver
+                    .FindElements(By.XPath(AppElements.Xpath[AppReference.Dialogs.DialogContext]))
+                    .LastOrDefault() ?? throw new NotFoundException("Unable to find a dialog.");
                 fieldContainer = formContext.WaitUntilAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.TextFieldContainer].Replace("[NAME]", field)));
             }
 


### PR DESCRIPTION
### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (updates to documentation, formatting, etc.)

### Description

Updated `ValidateFormContext` when dealing with `FormContextType.Dialog` to always return the topmost dialog.

### Issues addressed

Sometimes dialogs can be layered on top of each other. Previously it was returning the lowest dialog which was causing issues.

### All submissions:

- [x] My code follows the code style of this project.
- [x] Do existing samples that are effected by this change still run?
- [x] I have added samples for new functionality. 
- [x] I raise detailed error messages when possible.
- [x] My code does not rely on labels that have the option to be hidden.

### Which browsers was this tested on?
<!--- Should be tested on Chrome, Firefox, and IE. -->
- [x] Chrome
- [ ] Firefox
- [ ] IE
- [ ] Edge
