### PR TITLE
On a quick create form with a multi select option set, the flyout is not closing causing cover up of additional controls.

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/Microsoft.Dynamics365.UIAutomation.Api.UCI.csproj
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/Microsoft.Dynamics365.UIAutomation.Api.UCI.csproj
@@ -39,7 +39,7 @@
       <HintPath>..\packages\Microsoft.ApplicationInsights.2.21.0\lib\net46\Microsoft.ApplicationInsights.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.13.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.13.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="Otp.NET, Version=1.3.0.0, Culture=neutral, PublicKeyToken=38a48df817e173a6, processorArchitecture=MSIL">
       <HintPath>..\packages\Otp.NET.1.3.0\lib\net45\Otp.NET.dll</HintPath>
@@ -49,8 +49,8 @@
       <HintPath>..\packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
     </Reference>
     <Reference Include="System.Core" />
-    <Reference Include="System.Diagnostics.DiagnosticSource, Version=7.0.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.7.0.1\lib\net462\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=7.0.0.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.7.0.2\lib\net462\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Drawing" />
     <Reference Include="System.Memory, Version=4.0.1.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
@@ -72,10 +72,10 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
     <Reference Include="WebDriver, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Selenium.WebDriver.4.8.0\lib\net46\WebDriver.dll</HintPath>
+      <HintPath>..\packages\Selenium.WebDriver.4.10.0\lib\net46\WebDriver.dll</HintPath>
     </Reference>
     <Reference Include="WebDriver.Support, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Selenium.Support.4.8.0\lib\net46\WebDriver.Support.dll</HintPath>
+      <HintPath>..\packages\Selenium.Support.4.10.0\lib\net46\WebDriver.Support.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -131,12 +131,12 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Selenium.WebDriver.4.8.0\build\Selenium.WebDriver.targets" Condition="Exists('..\packages\Selenium.WebDriver.4.8.0\build\Selenium.WebDriver.targets')" />
+  <Import Project="..\packages\Selenium.WebDriver.4.10.0\build\Selenium.WebDriver.targets" Condition="Exists('..\packages\Selenium.WebDriver.4.10.0\build\Selenium.WebDriver.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Selenium.WebDriver.4.8.0\build\Selenium.WebDriver.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Selenium.WebDriver.4.8.0\build\Selenium.WebDriver.targets'))" />
+    <Error Condition="!Exists('..\packages\Selenium.WebDriver.4.10.0\build\Selenium.WebDriver.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Selenium.WebDriver.4.10.0\build\Selenium.WebDriver.targets'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -144,7 +144,9 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 
         private LoginResult Login(IWebDriver driver, Uri uri, SecureString username, SecureString password, SecureString mfaSecretKey = null, Action<LoginRedirectEventArgs> redirectAction = null)
         {
+            Trace.WriteLine("WebClient Login Start");
             bool online = !(OnlineDomains != null && !OnlineDomains.Any(d => uri.Host.EndsWith(d)));
+            Trace.WriteLine("Navigate to " + uri);
             driver.Navigate().GoToUrl(uri);
 
             if (!online)
@@ -153,6 +155,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             driver.ClickIfVisible(By.Id(Elements.ElementId[Reference.Login.UseAnotherAccount]));
 
             bool waitingForOtc = false;
+            Trace.WriteLine("Enter UserName");
             bool success = EnterUserName(driver, username);
             if (!success)
             {
@@ -184,7 +187,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                     redirectAction.Invoke(new LoginRedirectEventArgs(username, password, driver));
                     return LoginResult.Redirect;
                 }
-
+                Trace.WriteLine("Enter Password");
                 EnterPassword(driver, password);
                 ThinkTime(1000);
             }
@@ -194,6 +197,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             do
             {
                 entered = EnterOneTimeCode(driver, mfaSecretKey);
+                Trace.WriteLine("Click Stay Signed In");
                 success = ClickStaySignedIn(driver) || IsUserAlreadyLogged();
                 attempts++;
             }
@@ -3576,7 +3580,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                         }
                     }
                 }
-
+                fieldContainer.FindElement(flyoutCaretXPath).Click();
                 return true;
             });
         }

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/app.config
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/app.config
@@ -12,7 +12,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-7.0.0.1" newVersion="7.0.0.1" />
+        <bindingRedirect oldVersion="0.0.0.0-7.0.0.2" newVersion="7.0.0.2" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/packages.config
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/packages.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.ApplicationInsights" version="2.21.0" targetFramework="net462" />
-  <package id="Newtonsoft.Json" version="13.0.2" targetFramework="net462" />
+  <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net462" />
   <package id="Otp.NET" version="1.3.0" targetFramework="net462" />
-  <package id="Selenium.Support" version="4.8.0" targetFramework="net462" />
-  <package id="Selenium.WebDriver" version="4.8.0" targetFramework="net462" />
+  <package id="Selenium.Support" version="4.10.0" targetFramework="net462" />
+  <package id="Selenium.WebDriver" version="4.10.0" targetFramework="net462" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net462" />
-  <package id="System.Diagnostics.DiagnosticSource" version="7.0.1" targetFramework="net462" />
+  <package id="System.Diagnostics.DiagnosticSource" version="7.0.2" targetFramework="net462" />
   <package id="System.Memory" version="4.5.5" targetFramework="net462" />
   <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net462" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" targetFramework="net462" />

--- a/Microsoft.Dynamics365.UIAutomation.Browser/BrowserCommand.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Browser/BrowserCommand.cs
@@ -105,6 +105,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Browser
                 }
                 catch (Exception e)
                 {
+                    driver.TakeScreenshot();
                     bool canRetry = false;
                     if (retries < maxRetryAttempts)
                         if (retries < maxRetryAttemptsNotIgnoredExceptions)

--- a/Microsoft.Dynamics365.UIAutomation.Browser/Microsoft.Dynamics365.UIAutomation.Browser.csproj
+++ b/Microsoft.Dynamics365.UIAutomation.Browser/Microsoft.Dynamics365.UIAutomation.Browser.csproj
@@ -42,7 +42,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.13.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.13.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="SeleniumExtras.WaitHelpers, Version=3.11.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\DotNetSeleniumExtras.WaitHelpers.3.11.0\lib\net45\SeleniumExtras.WaitHelpers.dll</HintPath>

--- a/Microsoft.Dynamics365.UIAutomation.Browser/packages.config
+++ b/Microsoft.Dynamics365.UIAutomation.Browser/packages.config
@@ -3,7 +3,7 @@
     Licensed under the MIT license.-->
 <packages>
   <package id="DotNetSeleniumExtras.WaitHelpers" version="3.11.0" targetFramework="net462" />
-  <package id="Newtonsoft.Json" version="13.0.2" targetFramework="net462" />
+  <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net462" />
   <package id="Selenium.Support" version="4.8.0" targetFramework="net462" />
   <package id="Selenium.WebDriver" version="4.8.0" targetFramework="net462" />
 </packages>

--- a/Microsoft.Dynamics365.UIAutomation.Sample/AzureDevOps/UCI/RegressionTests.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Sample/AzureDevOps/UCI/RegressionTests.cs
@@ -86,8 +86,10 @@ namespace Microsoft.Dynamics365.UIAutomation.Sample.UCI
             var xrmApp = new XrmApp(client);
             try
             {
+                Trace.WriteLine("Login Started");
                 telemetry.TrackTrace("Login Started");
                 xrmApp.OnlineLogin.Login(_xrmUri, _username, _password, _mfaSecretKey);
+                Trace.WriteLine("Login Completed");
                 telemetry.TrackTrace("Login Completed");
                 TakeScreenshot(client, xrmApp.CommandResults.Last());
                 //xrmApp.Navigation.OpenApp(UCIAppName.Sales);

--- a/Microsoft.Dynamics365.UIAutomation.Sample/Microsoft.Dynamics365.UIAutomation.Sample.csproj
+++ b/Microsoft.Dynamics365.UIAutomation.Sample/Microsoft.Dynamics365.UIAutomation.Sample.csproj
@@ -69,10 +69,10 @@
     </Reference>
     <Reference Include="System.Web.Extensions" />
     <Reference Include="WebDriver, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Selenium.WebDriver.4.9.1\lib\net46\WebDriver.dll</HintPath>
+      <HintPath>..\packages\Selenium.WebDriver.4.11.0\lib\net46\WebDriver.dll</HintPath>
     </Reference>
     <Reference Include="WebDriver.Support, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Selenium.Support.4.9.1\lib\net46\WebDriver.Support.dll</HintPath>
+      <HintPath>..\packages\Selenium.Support.4.11.0\lib\net46\WebDriver.Support.dll</HintPath>
     </Reference>
   </ItemGroup>
   <Choose>
@@ -309,13 +309,13 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Selenium.WebDriver.ChromeDriver.113.0.5672.6300\build\Selenium.WebDriver.ChromeDriver.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Selenium.WebDriver.ChromeDriver.113.0.5672.6300\build\Selenium.WebDriver.ChromeDriver.targets'))" />
     <Error Condition="!Exists('..\packages\Selenium.Firefox.WebDriver.0.27.0\build\Selenium.Firefox.WebDriver.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Selenium.Firefox.WebDriver.0.27.0\build\Selenium.Firefox.WebDriver.targets'))" />
-    <Error Condition="!Exists('..\packages\Selenium.WebDriver.4.9.1\build\Selenium.WebDriver.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Selenium.WebDriver.4.9.1\build\Selenium.WebDriver.targets'))" />
+    <Error Condition="!Exists('..\packages\Selenium.WebDriver.4.11.0\build\Selenium.WebDriver.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Selenium.WebDriver.4.11.0\build\Selenium.WebDriver.targets'))" />
+    <Error Condition="!Exists('..\packages\Selenium.WebDriver.ChromeDriver.116.0.5845.9600\build\Selenium.WebDriver.ChromeDriver.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Selenium.WebDriver.ChromeDriver.116.0.5845.9600\build\Selenium.WebDriver.ChromeDriver.targets'))" />
   </Target>
-  <Import Project="..\packages\Selenium.WebDriver.ChromeDriver.113.0.5672.6300\build\Selenium.WebDriver.ChromeDriver.targets" Condition="Exists('..\packages\Selenium.WebDriver.ChromeDriver.113.0.5672.6300\build\Selenium.WebDriver.ChromeDriver.targets')" />
   <Import Project="..\packages\Selenium.Firefox.WebDriver.0.27.0\build\Selenium.Firefox.WebDriver.targets" Condition="Exists('..\packages\Selenium.Firefox.WebDriver.0.27.0\build\Selenium.Firefox.WebDriver.targets')" />
-  <Import Project="..\packages\Selenium.WebDriver.4.9.1\build\Selenium.WebDriver.targets" Condition="Exists('..\packages\Selenium.WebDriver.4.9.1\build\Selenium.WebDriver.targets')" />
+  <Import Project="..\packages\Selenium.WebDriver.4.11.0\build\Selenium.WebDriver.targets" Condition="Exists('..\packages\Selenium.WebDriver.4.11.0\build\Selenium.WebDriver.targets')" />
+  <Import Project="..\packages\Selenium.WebDriver.ChromeDriver.116.0.5845.9600\build\Selenium.WebDriver.ChromeDriver.targets" Condition="Exists('..\packages\Selenium.WebDriver.ChromeDriver.116.0.5845.9600\build\Selenium.WebDriver.ChromeDriver.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Microsoft.Dynamics365.UIAutomation.Sample/app.config
+++ b/Microsoft.Dynamics365.UIAutomation.Sample/app.config
@@ -22,7 +22,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-7.0.0.1" newVersion="7.0.0.1" />
+        <bindingRedirect oldVersion="0.0.0.0-7.0.0.2" newVersion="7.0.0.2" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Microsoft.Dynamics365.UIAutomation.Sample/packages.config
+++ b/Microsoft.Dynamics365.UIAutomation.Sample/packages.config
@@ -5,9 +5,9 @@
   <package id="Microsoft.ApplicationInsights" version="2.21.0" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net462" />
   <package id="Selenium.Firefox.WebDriver" version="0.27.0" targetFramework="net462" />
-  <package id="Selenium.Support" version="4.9.1" targetFramework="net462" />
-  <package id="Selenium.WebDriver" version="4.9.1" targetFramework="net462" />
-  <package id="Selenium.WebDriver.ChromeDriver" version="114.0.5735.9000" targetFramework="net462" />
+  <package id="Selenium.Support" version="4.11.0" targetFramework="net462" />
+  <package id="Selenium.WebDriver" version="4.11.0" targetFramework="net462" />
+  <package id="Selenium.WebDriver.ChromeDriver" version="116.0.5845.9600" targetFramework="net462" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net462" />
   <package id="System.Diagnostics.DiagnosticSource" version="7.0.2" targetFramework="net462" />
   <package id="System.Memory" version="4.5.5" targetFramework="net462" />


### PR DESCRIPTION
### Type of change
Multi Option Select in Quick Create flyout not closing

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (updates to documentation, formatting, etc.)

### Description
Added an extra click on the flyout element once options were selected.

### Issues addressed
On a quick create form with a multi select option set, the flyout is not closing causing cover up of additional controls.

### All submissions:

- [X] My code follows the code style of this project.
- [X] Do existing samples that are effected by this change still run?
- [ ] I have added samples for new functionality. 
- [ ] I raise detailed error messages when possible.
- [ ] My code does not rely on labels that have the option to be hidden.

### Which browsers was this tested on?
<!--- Should be tested on Chrome, Firefox, and IE. -->
- [X] Chrome
- [ ] Firefox
- [ ] IE
- [ ] Edge
