### PR TITLE
feat: Added method to open subareas in the Customer Service Workspace

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/Elements/Navigation.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/Elements/Navigation.cs
@@ -55,6 +55,17 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         }
 
         /// <summary>
+        /// Opens the Customer Service Workspace sub area in the unified client
+        /// </summary>
+        /// <param name="area">Name of the area</param>
+        /// /// <param name="subarea">Name of the subarea</param>
+        public void OpenSubAreaCSW(string area, string subarea)
+        {
+            _client.OpenSubArea(area);
+            _client.OpenSubArea(subarea);
+        }
+
+        /// <summary>
         /// Opens a sub area in the unified client
         /// </summary>
         /// <param name="area">Name of the area</param>


### PR DESCRIPTION
### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (updates to documentation, formatting, etc.)

### Description
<!--- Describe your changes -->
The OpenSubAreaCSW method was added to handle navigation within the Customer Service Workspace (CSW) in the unified client. The existing OpenSubArea method did not work correctly in the CSW environment. This new method separately opens the specified area and subarea, ensuring that navigation behaves as expected within the CSW. The change improves the reliability and functionality of the code when interacting with the Customer Service Workspace.

### Issues addressed
<!--- Why is this change required? What problem does it solve? -->
This change was required because the existing method:
`/// <summary>
/// Opens a sub area in the unified client
/// </summary>
/// <param name="area">Name of the area</param>
/// <param name="subarea">Name of the subarea</param>
public void OpenSubArea(string area, string subarea)
{
    _client.OpenSubArea(area, subarea);
}`
did not function correctly in the Customer Service Workspace (CSW). The new method, OpenSubAreaCSW, was implemented to specifically handle the navigation within the CSW, ensuring that both the area and subarea are opened as expected.
<!--- If it fixes an open issue, please link to the issue here. -->

### All submissions:

- [x] My code follows the code style of this project.
- [ ] Do existing samples that are effected by this change still run?
- [ ] I have added samples for new functionality. 
- [ ] I raise detailed error messages when possible.
- [ ] My code does not rely on labels that have the option to be hidden.

### Which browsers was this tested on?
<!--- Should be tested on Chrome, Firefox, and IE. -->
- [x] Chrome
- [ ] Firefox
- [ ] IE
- [ ] Edge
